### PR TITLE
Remove the assertion in checking if somatic mutations are consistency.

### DIFF
--- a/immunopepper/utils.py
+++ b/immunopepper/utils.py
@@ -194,7 +194,6 @@ def get_sub_mut_dna(background_seq, coord,variant_comb, mutation_sub_dic_maf, st
         pos = relative_variant_pos[i]
         if pos != NOT_EXIST:
         # strand = mutation_sub_dic_maf[variant_ipos]['strand']
-            assert (sub_dna[pos] == ref_base)
             sub_dna = sub_dna[:pos]+mut_base+sub_dna[pos+1:]
 
     return sub_dna


### PR DESCRIPTION
Originally, if there is an error, we will skip the current gene and go to
the next one. After discussion, we think this error is not important.
Sometimes there might be some inconsistency between maf file and
genome for the reference gene. It is however not a problem for our
case (will not bring new kmer or miss kmer). In this way, there is no
need to skip the gene.