### PR TITLE
Feature/rf flag refine

### DIFF
--- a/immunopepper/namedtuples.py
+++ b/immunopepper/namedtuples.py
@@ -116,7 +116,7 @@ Reading_frame_tuple namedtuple
 - cds_left_modi: int, modified left cds coordinate. (modifies means read frame shift has already been considered)
 - cds_right_modi: int, modified right cds coordinate
 - read_phase: (0,1,2). the number of bases left for the next cds
-- annotated_RF: bool. True if a transcript in the given reading frame is present in the annotation,
+- annotated_RF: list(bool). True if a transcript in the given reading frame is present in the annotation,
   False if it is created by propagation
 """
 ReadingFrameTuple = namedtuple('ReadingFrameTuple', ['cds_left_modi', 'cds_right_modi', 'read_phase', 'annotated_RF'])

--- a/immunopepper/preprocess.py
+++ b/immunopepper/preprocess.py
@@ -44,7 +44,7 @@ def genes_preprocess_batch(genes, gene_idxs, gene_cds_begin_dict, all_read_frame
         vertex_len_dict = {}
         if not all_read_frames:
             for idx in vertex_order:
-                reading_frames[idx] = set()
+                reading_frames[idx] = list()
                 v_start = gene.splicegraph.vertices[0, idx]
                 v_stop = gene.splicegraph.vertices[1, idx]
                 cds_begins = find_overlapping_cds_simple(v_start, v_stop, gene_cds_begin_dict[gene.name], gene.strand)
@@ -71,10 +71,12 @@ def genes_preprocess_batch(genes, gene_idxs, gene_cds_begin_dict, all_read_frame
 
                     read_phase = n_trailing_bases % 3
                     # add all reading frames from the annotation
-                    reading_frames[idx].add(ReadingFrameTuple(cds_left_modi=cds_left_modi,
+                    reading_frame = ReadingFrameTuple(cds_left_modi=cds_left_modi,
                                                               cds_right_modi=cds_right_modi,
                                                               read_phase=read_phase,
-                                                              annotated_RF=True))
+                                                              annotated_RF=[True]) # annotated_RF is now mutable
+                    if reading_frame not in reading_frames[idx]:
+                        reading_frames[idx].append(reading_frame)
         gene.to_sparse()
         gene_info.append(GeneInfo(vertex_succ_list, vertex_order, reading_frames, vertex_len_dict, gene.splicegraph.vertices.shape[1]))
 

--- a/immunopepper/preprocess.py
+++ b/immunopepper/preprocess.py
@@ -13,6 +13,7 @@ from immunopepper.namedtuples import CountInfo
 from immunopepper.namedtuples import GeneInfo
 from immunopepper.namedtuples import GeneTable
 from immunopepper.namedtuples import ReadingFrameTuple
+from immunopepper.translate import read_frame_flag_strict
 from immunopepper.utils import encode_chromosome
 from immunopepper.utils import find_overlapping_cds_simple
 from immunopepper.utils import get_successor_list
@@ -70,13 +71,16 @@ def genes_preprocess_batch(genes, gene_idxs, gene_cds_begin_dict, all_read_frame
                         n_trailing_bases = cds_right_modi - cds_left_modi
 
                     read_phase = n_trailing_bases % 3
-                    # add all reading frames from the annotation
+                    #  add all reading frames from the annotation
+                    reading_frame_flag = read_frame_flag_strict(cds_begin[1], cds_left_modi, cds_right_modi,
+                                v_stop, reading_frames[idx], gene.strand)
                     reading_frame = ReadingFrameTuple(cds_left_modi=cds_left_modi,
-                                                              cds_right_modi=cds_right_modi,
-                                                              read_phase=read_phase,
-                                                              annotated_RF=[True]) # annotated_RF is now mutable
+                                                      cds_right_modi=cds_right_modi,
+                                                      read_phase=read_phase,
+                                                      annotated_RF=reading_frame_flag)  # annotated_RF is now mutable
                     if reading_frame not in reading_frames[idx]:
                         reading_frames[idx].append(reading_frame)
+
         gene.to_sparse()
         gene_info.append(GeneInfo(vertex_succ_list, vertex_order, reading_frames, vertex_len_dict, gene.splicegraph.vertices.shape[1]))
 

--- a/immunopepper/preprocess.py
+++ b/immunopepper/preprocess.py
@@ -62,18 +62,18 @@ def genes_preprocess_batch(genes, gene_idxs, gene_cds_begin_dict, all_read_frame
 
                     #TODO: need to remove the redundance of (cds_start, cds_stop, item)
                     if gene.strand == "-":
-                        cds_right_modi = max(cds_right - cds_phase,v_start)
+                        cds_right_modi = max(cds_right - cds_phase, v_start)
                         cds_left_modi = v_start
                         n_trailing_bases = cds_right_modi - cds_left_modi
                     else:
-                        cds_left_modi = min(cds_left + cds_phase,v_stop)
+                        cds_left_modi = min(cds_left + cds_phase, v_stop)
                         cds_right_modi = v_stop
                         n_trailing_bases = cds_right_modi - cds_left_modi
 
                     read_phase = n_trailing_bases % 3
                     #  add all reading frames from the annotation
                     reading_frame_flag = read_frame_flag_strict(cds_begin[1], cds_left_modi, cds_right_modi,
-                                v_stop, reading_frames[idx], gene.strand)
+                                                                reading_frames[idx], gene.strand)
                     reading_frame = ReadingFrameTuple(cds_left_modi=cds_left_modi,
                                                       cds_right_modi=cds_right_modi,
                                                       read_phase=read_phase,

--- a/immunopepper/spark.py
+++ b/immunopepper/spark.py
@@ -196,7 +196,7 @@ def filter_on_junction_kmer_annotated_flag(matrix, jct_annot_col, rf_annot_col, 
     if filterNeojuncCoord:
         matrix = matrix.filter(f'({jct_annot_col} == {False})')
     if filterAnnotatedRF:
-        matrix = matrix.filter(f'({rf_annot_col} == {True})')
+        matrix = matrix.filter(f'({rf_annot_col} == {True}) OR ({rf_annot_col} is null)')
     return matrix
 
 

--- a/immunopepper/translate.py
+++ b/immunopepper/translate.py
@@ -270,18 +270,23 @@ def get_exhaustive_reading_frames(splicegraph, gene_strand, vertex_order):
     return reading_frames
 
 
-def read_frame_flag_strict(cds_end, cds_begin_phased, cds_end_phased,
-                                v_stop_exon, reading_frames_list_exon, strand):
+def read_frame_flag_strict(cds_end, cds_begin_phased, cds_end_phased, reading_frames_list_exon, strand):
     '''
-    :param cds_end:
-    :param cds_begin_phased:
-    :param cds_end_phased:
-    :param v_stop_exon:
-    :param reading_frames_list_exon:
-    :param strand:
-    :return:
+    :param cds_end: int.
+    - if strand == '+' this is the largest CDS coordinate from the annotation
+    - elif strand == '-' this is the smallest coordinate CDS from the annotation with a -1 shift to get pythonic coordinate
+    :param cds_begin_phased: int.
+    - if strand == '+' this is the smallest CDS coordinate from the annotation with a -1 shift plus read phase (unless the exon ends before) => READ FRAME START PHASED
+    - elif strand == '-' this is the smallest coordinate of the vertex from the graph => EXON END
+    :param cds_end_phased: int
+    - if strand == '+' this is the biggest coordinate of the vertex from the graph => EXON END
+    - elif strand == '-' this is the biggest CDS coordinate from the annotation minus read phase (unless the exon ends before) => READ FRAME START PHASED
+    :param reading_frames_list_exon: list of ReadingFrameTuples currently associated with the exon
+    :param strand: str. gene strand
+    :return: reading_frame_flag: list of bool. Flag indicating whether a given reading frame is found in the annotation
     '''
     # Remark v_start <= cds_begin per check with find_overlapping_cds_simple above.
+    v_stop_exon = cds_end_phased if strand == '+' else cds_begin_phased # by definition
     if leq_strand(cds_end, v_stop_exon, strand):  # cds_end inside exon
         if (not reading_frames_list_exon) or has_same_reading_frame(reading_frames_list_exon,
                                                                     cds_begin_phased,

--- a/immunopepper/translate.py
+++ b/immunopepper/translate.py
@@ -261,5 +261,5 @@ def get_exhaustive_reading_frames(splicegraph, gene_strand, vertex_order):
                 cds_right_modi = v_stop
             n_trailing_bases = cds_right_modi - cds_left_modi
             read_phase = n_trailing_bases % 3
-            reading_frames[idx].add(ReadingFrameTuple(cds_left_modi, cds_right_modi, read_phase, False )) #no reading frame annotation status recorded 
+            reading_frames[idx].add(ReadingFrameTuple(cds_left_modi, cds_right_modi, read_phase, [False] )) #no reading frame annotation status recorded
     return reading_frames

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 import numpy as np
+from operator import attrgetter
 
 from immunopepper.filter import add_kmers
 from immunopepper.filter import filter_redundant_junctions
@@ -119,7 +120,7 @@ def collect_vertex_pairs(gene=None, gene_info=None, ref_seq_file=None, chrm=None
         for prop_vertex in gene_info.vertex_succ_list[v_id]:
             vertex_list = [v_id, prop_vertex]
             mut_seq_comb = get_mut_comb(exon_som_dict,vertex_list)
-            for read_frame_tuple in sorted(reading_frame_dict[v_id]):
+            for read_frame_tuple in sorted(reading_frame_dict[v_id], key=attrgetter('cds_left_modi')):
                 has_stop_flag = True
                 for variant_comb in mut_seq_comb:  # go through each variant combination
                     if prop_vertex is not np.nan:
@@ -597,7 +598,6 @@ def create_output_kmer_cross_samples(output_peptide, k, segm_expr_list, graph_ou
                 row_metadata = [kmer_peptide, is_in_junction, junction_annotated, output_peptide.read_frame_annotated]
                 kmer_matrix_edge.add(tuple(row_metadata + list(sublist_jun)))
                 kmer_matrix_segm.add(tuple(row_metadata + list(np.round(sublist_seg, 2))))
-
 
 
 

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -128,9 +128,11 @@ def collect_vertex_pairs(gene=None, gene_info=None, ref_seq_file=None, chrm=None
                         # no propagation needed in all reading frame mode,  RF not labelled as annotated
                         if (not flag.has_stop) and (not all_read_frames) \
                             and (not ReadingFrameTuple(next_start_v1, next_stop_v1,
-                                                       next_emitting_frame, True) in reading_frame_dict[prop_vertex] ):
-                            reading_frame_dict[prop_vertex].add(ReadingFrameTuple(next_start_v1,
-                                                                                  next_stop_v1, next_emitting_frame, False))
+                                                       next_emitting_frame, [True]) in reading_frame_dict[prop_vertex] )\
+                            and (not ReadingFrameTuple(next_start_v1, next_stop_v1,
+                                                       next_emitting_frame, [False]) in reading_frame_dict[prop_vertex] ) : #TODO complete change planned
+                            reading_frame_dict[prop_vertex].append(ReadingFrameTuple(next_start_v1,
+                                                                                  next_stop_v1, next_emitting_frame, [False]))
                     else:
                         peptide, modi_coord, flag = isolated_peptide_result(read_frame_tuple, gene.strand, variant_comb, mutation.somatic_dict, ref_mut_seq, min_pos, all_read_frames)
                         orig_coord = Coord(sg.vertices[0, v_id],sg.vertices[1, v_id], np.nan, np.nan)
@@ -317,7 +319,7 @@ def get_and_write_peptide_and_kmer(peptide_set=None, kmer_dict=None,
                     peptide_set.add(namedtuple_to_str(OutputMetadata(peptide=peptide.mut[pep_idx],
                                        output_id=new_output_id,
                                        read_frame=vertex_pair.read_frame.read_phase,
-                                       read_frame_annotated=vertex_pair.read_frame.annotated_RF,
+                                       read_frame_annotated=vertex_pair.read_frame.annotated_RF[0],
                                        gene_name=gene.name,
                                        gene_chr=gene.chr,
                                        gene_strand=gene.strand,
@@ -341,7 +343,7 @@ def get_and_write_peptide_and_kmer(peptide_set=None, kmer_dict=None,
                                                     exons_coor=modi_coord,
                                                     junction_expr=edge_expr,
                                                     junction_annotated=vertex_tuple_anno_flag,
-                                                    read_frame_annotated=vertex_pair.read_frame.annotated_RF)
+                                                    read_frame_annotated=vertex_pair.read_frame.annotated_RF[0])
 
                     ### kmers
                     if cross_graph_expr: #generate kmer x sample expression matrix for all samples in graph

--- a/immunopepper/utils.py
+++ b/immunopepper/utils.py
@@ -72,6 +72,19 @@ def leq_strand(coord1, coord2, strand):
     else:
         return coord1 >= coord2
 
+def has_same_reading_frame(list_ReadingFrameTuple, cds_left_modi, cds_right_modi, strand):
+    '''
+    :param list_ReadingFrameTuple: list of ReadingFrameTuple namedtuples. Contains all reading frames of the vertex
+    :param cds_left_modi: int. left coordinate of the modified CDS after phase propagation
+    :param cds_right_modi: int. right coordinate of the modified CDS after phase propagation
+    :param strand: str. gene strand
+    :return: whether list_ReadingFrameTuple contains a reading frame with the same phasing as (cds_left_modi, cds_right)
+    '''
+    return 0 in [(other_read_frame.cds_left_modi - cds_left_modi) % 3
+                 if strand == '+'
+                 else (other_read_frame.cds_right_modi - cds_right_modi) %3
+                 for other_read_frame in list_ReadingFrameTuple]
+
 
 def encode_chromosome(in_num):
     """  Encodes human chromosome numbers to strings (23==X, 24==Y, 25 ==MT, the rest remain unchanged. """

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -243,7 +243,7 @@ mutation_mode ='ref'
 #pr = cProfile.Profile()
 #pr.enable()
 #for mutation_mode in ['ref', 'somatic', 'germline', 'somatic_and_germline']:
-test_end_to_end_build_mouse(tmpdir, mutation_mode, is_parallel=False, graph_cross_sample=True) #TODO add back
+#test_end_to_end_build_mouse(tmpdir, mutation_mode, is_parallel=False, graph_cross_sample=True) #TODO add back
 #test_end_to_end_samplespecif('ERR2130621', tmpdir, "9", mutation_mode) # TEST DEPRECATED
 #test_end_to_end_filter(tmpdir, 'ERR2130621', "9", mutation_mode)
 #for mutation_mode in ['ref', 'germline', 'somatic', 'somatic_and_germline']:
@@ -253,7 +253,7 @@ test_end_to_end_build_mouse(tmpdir, mutation_mode, is_parallel=False, graph_cros
 #test_end_to_end_crosscohort(tmpdir) #TODO add back
 #mini_crosscohort()
 #test_end_to_end_cancerspecif()
-#test_end_to_end_cancerspecif_mx()
+test_end_to_end_cancerspecif_mx()
 #pr.disable()
 #pr.dump_stats(os.path.join(tmpdir, 'cProfile.pstats'))
 


### PR DESCRIPTION
Determines whether the reading frame of an exon is from the annotation, or from another path

- True if the reading frame of the exon unambigously matches the reading frame of the annotated transcript

- False if the reading frame of the exon can unambigously be assigned to another annotated transcript ("propagated")

- None if more than one reading frame can be applied to the exon regardless of whether this is the result of

         1) two annotated transcripts with different reading frames containing exactly the same exon
         2) a novel propagated path through the graph