### PR TITLE
Experimental/global variables

### DIFF
--- a/immunopepper/mode_build.py
+++ b/immunopepper/mode_build.py
@@ -314,8 +314,8 @@ def process_gene_batch_foreground(output_sample, mutation_sample, output_samples
                           f'max time cost: {np.round(np.nanmax(time_per_gene), 2)}, '
                           f'memory cost: {np.round(np.nanmax(mem_per_gene), 2)} GB')
             logging.debug(logging_string)
-	else:
-	    logging_string = (f'....{output_sample}: output_sample graph from batch {batch_name}/{n_genes}, no processing')
+        else:
+            logging_string = (f'....{output_sample}: output_sample graph from batch {batch_name}/{n_genes}, no processing')
         if (batch_name != 'all') and (batch_name % 10000 == 0):
             logging.info(logging_string)
 

--- a/immunopepper/mode_build.py
+++ b/immunopepper/mode_build.py
@@ -137,6 +137,8 @@ def process_gene_batch_background(output_sample, mutation_sample, genes, gene_id
                               f'processed, max time cost: {np.round(np.nanmax(time_per_gene), 2)}, '
                               f'memory cost: {np.round(np.nanmax(mem_per_gene), 2)} GB')
             logging.debug(logging_string)
+        else:
+            logging_string = (f'....{output_sample}: output_sample graph from batch {batch_name}/{n_genes}, no processing')
 
         if (batch_name != 'all') and (batch_name % 10000 == 0):
             logging.info(logging_string)
@@ -312,7 +314,8 @@ def process_gene_batch_foreground(output_sample, mutation_sample, output_samples
                           f'max time cost: {np.round(np.nanmax(time_per_gene), 2)}, '
                           f'memory cost: {np.round(np.nanmax(mem_per_gene), 2)} GB')
             logging.debug(logging_string)
-
+	else:
+	    logging_string = (f'....{output_sample}: output_sample graph from batch {batch_name}/{n_genes}, no processing')
         if (batch_name != 'all') and (batch_name % 10000 == 0):
             logging.info(logging_string)
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -243,7 +243,7 @@ mutation_mode ='ref'
 #pr = cProfile.Profile()
 #pr.enable()
 #for mutation_mode in ['ref', 'somatic', 'germline', 'somatic_and_germline']:
-#test_end_to_end_build_mouse(tmpdir, mutation_mode, is_parallel=False, graph_cross_sample=True) #TODO add back
+test_end_to_end_build_mouse(tmpdir, mutation_mode, is_parallel=False, graph_cross_sample=True) #TODO add back
 #test_end_to_end_samplespecif('ERR2130621', tmpdir, "9", mutation_mode) # TEST DEPRECATED
 #test_end_to_end_filter(tmpdir, 'ERR2130621', "9", mutation_mode)
 #for mutation_mode in ['ref', 'germline', 'somatic', 'somatic_and_germline']:
@@ -252,7 +252,7 @@ mutation_mode ='ref'
 #    test_end_to_end_filter(tmpdir, 'ERR2130621', "9", mutation_mode)
 #test_end_to_end_crosscohort(tmpdir) #TODO add back
 #mini_crosscohort()
-test_end_to_end_cancerspecif()
+#test_end_to_end_cancerspecif()
 #test_end_to_end_cancerspecif_mx()
 #pr.disable()
 #pr.dump_stats(os.path.join(tmpdir, 'cProfile.pstats'))


### PR DESCRIPTION
Moved the countinfo, genetable and kmer_database object as global variables in order to reduce pickling burden of multiprocessing