### PR TITLE
Feature/lighterweight

### DIFF
--- a/immunopepper/io_.py
+++ b/immunopepper/io_.py
@@ -198,51 +198,28 @@ def save_kmer_matrix(data_edge, data_segm, kmer_len, graph_samples, filepointer:
     :param out_dir: str output directory path
     :param verbose: int verbose parameter
     '''
-    logging.info("Start get file pointer")
     segm_path = get_save_path(filepointer.kmer_segm_expr_fp, out_dir, create_partitions=True)
     edge_path = get_save_path(filepointer.kmer_edge_expr_fp, out_dir, create_partitions=True)
-    logging.info("Stop get file pointer")
-    logging.info(f'Number of samples is {len(graph_samples)}')
-    logging.info("Start creating data type array")
     dt = [('kmer', 'S' + str(kmer_len)), ('isCrossJunction', 'bool'), ('junctionAnnotated', 'bool'),
           ('readFrameAnnotated', 'bool') ] + [ (f'{sample}', 'float') for sample in graph_samples]
-    logging.info("Stop creating datatype array")
     if data_edge:
-        logging.info("***Start Save EDGE***")
-        logging.info(f'Number of kmers to save (x patients) is {len(data_edge)}')
-        logging.info("...Start From Iter")
         data_edge = np.fromiter(data_edge, dt, -1) #set to array
-        logging.info("...Stop From Iter")
-        logging.info("...Start structured to unstructured")
         data_edge = structured_to_unstructured(data_edge)
-        logging.info("...Stop structured to unstructured")
-        logging.info("...Start transpose")
         data_edge = data_edge.T
-        logging.info("...Stop transpose")
         data_edge_columns = filepointer.kmer_segm_expr_fp['columns'] + graph_samples
         filepointer.kmer_edge_expr_fp['pqwriter'] = save_pd_toparquet(edge_path, data_edge, data_edge_columns,
                                                                       compression=compression, verbose=verbose,
                                                                       pqwriter=filepointer.kmer_edge_expr_fp[
                                                                           'pqwriter'], writer_close=True)
-        logging.info("***Stop Save EDGE***")
     if data_segm:
-        logging.info("****Start save SEGM***")
-        logging.info(f'Number of kmers to save (x patients) is {len(data_segm)}')
-        logging.info("...Start From Iter")
         data_segm = np.fromiter(data_segm, dt, -1) #set to array
-        logging.info("...Stop From Iter")
-        logging.info("...Start structured to unstructured")
         data_segm = structured_to_unstructured(data_segm)
-        logging.info("...Stop structured to unstructured")
-        logging.info("...Start transpose")
         data_segm = data_segm.T
-        logging.info("...Stop transpose")
         data_segm_columns = filepointer.kmer_segm_expr_fp['columns'] + graph_samples
         filepointer.kmer_segm_expr_fp['pqwriter'] = save_pd_toparquet(segm_path, data_segm, data_segm_columns,
                                                                       compression=compression, verbose=verbose,
                                                                       pqwriter=filepointer.kmer_segm_expr_fp[
                                                                           'pqwriter'], writer_close=True)
-        logging.info("****Stop save SEGM****")
 
 
 
@@ -327,18 +304,12 @@ def save_pd_toparquet(path, array, columns, compression=None, verbose=False, pqw
     Saves a pandas data frame in parquet format.
     """
     s1 = timeit.default_timer()
-    logging.info("......Start convert pyarrow")
     table = pa.Table.from_arrays(array, names = columns)
-    logging.info("......Stop convert pyarrow")
     if pqwriter is None:
-        logging.info("......Start writer")
         pqwriter = pq.ParquetWriter(path, table.schema, compression=compression)
     pqwriter.write_table(table)
-    logging.info("......Stop writer")
     if writer_close:
-        logging.info("......Start close writer")
         pqwriter.close()
-        logging.info("......Stop close writer")
         pqwriter = None
 
     if verbose:

--- a/immunopepper/io_.py
+++ b/immunopepper/io_.py
@@ -179,30 +179,51 @@ def save_kmer_matrix(data_edge, data_segm, kmer_len, graph_samples, filepointer:
     :param out_dir: str output directory path
     :param verbose: int verbose parameter
     '''
-
+    logging.info("Start get file pointer")
     segm_path = get_save_path(filepointer.kmer_segm_expr_fp, out_dir)
     edge_path = get_save_path(filepointer.kmer_edge_expr_fp, out_dir)
+    logging.info("Stop get file pointer")
+    logging.info(f'Number of samples is {len(graph_samples)}')
+    logging.info("Start creating data type array")
     dt = [('kmer', 'S' + str(kmer_len)), ('isCrossJunction', 'bool'), ('junctionAnnotated', 'bool'),
           ('readFrameAnnotated', 'bool') ] + [ (f'{sample}', 'float') for sample in graph_samples]
+    logging.info("Stop creating datatype array")
     if data_edge:
+        logging.info("***Start Save EDGE***")
+        logging.info(f'Number of kmers to save (x patients) is {len(data_edge)}')
+        logging.info("...Start From Iter")
         data_edge = np.fromiter(data_edge, dt, -1) #set to array
+        logging.info("...Stop From Iter")
+        logging.info("...Start structured to unstructured")
         data_edge = structured_to_unstructured(data_edge)
+        logging.info("...Stop structured to unstructured")
+        logging.info("...Start transpose")
         data_edge = data_edge.T
+        logging.info("...Stop transpose")
         data_edge_columns = filepointer.kmer_segm_expr_fp['columns'] + graph_samples
         filepointer.kmer_edge_expr_fp['pqwriter'] = save_pd_toparquet(edge_path, data_edge, data_edge_columns,
                                                                       compression=compression, verbose=verbose,
                                                                       pqwriter=filepointer.kmer_edge_expr_fp[
                                                                           'pqwriter'], writer_close=False)
+        logging.info("***Stop Save EDGE***")
     if data_segm:
+        logging.info("****Start save SEGM***")
+        logging.info(f'Number of kmers to save (x patients) is {len(data_segm)}')
+        logging.info("...Start From Iter")
         data_segm = np.fromiter(data_segm, dt, -1) #set to array
+        logging.info("...Stop From Iter")
+        logging.info("...Start structured to unstructured")
         data_segm = structured_to_unstructured(data_segm)
+        logging.info("...Stop structured to unstructured")
+        logging.info("...Start transpose")
         data_segm = data_segm.T
+        logging.info("...Stop transpose")
         data_segm_columns = filepointer.kmer_segm_expr_fp['columns'] + graph_samples
         filepointer.kmer_segm_expr_fp['pqwriter'] = save_pd_toparquet(segm_path, data_segm, data_segm_columns,
                                                                       compression=compression, verbose=verbose,
                                                                       pqwriter=filepointer.kmer_segm_expr_fp[
                                                                           'pqwriter'], writer_close=False)
-
+        logging.info("****Stop save SEGM****")
 
 
 
@@ -287,13 +308,18 @@ def save_pd_toparquet(path, array, columns, compression=None, verbose=False, pqw
     Saves a pandas data frame in parquet format.
     """
     s1 = timeit.default_timer()
+    logging.info("......Start convert pyarrow")
     table = pa.Table.from_arrays(array, names = columns)
-
+    logging.info("......Stop convert pyarrow")
     if pqwriter is None:
+        logging.info("......Start writer")
         pqwriter = pq.ParquetWriter(path, table.schema, compression=compression)
     pqwriter.write_table(table)
+    logging.info("......Stop writer")
     if writer_close:
+        logging.info("......Start close writer")
         pqwriter.close()
+        logging.info("......Stop close writer")
 
     if verbose:
         file_name = os.path.basename(path)

--- a/immunopepper/mode_build.py
+++ b/immunopepper/mode_build.py
@@ -384,7 +384,7 @@ def mode_build(arg):
 
     ### DEBUG
     #graph_data = graph_data[[3170]] #TODO remove
-    #graph_data = graph_data[0:110]
+    graph_data = graph_data[940:942]
     if arg.start_id != 0 and arg.start_id < len(graph_data):
         logging.info(f'development feature: starting at gene number {arg.start_id}')
         graph_data = graph_data[arg.start_id:]

--- a/immunopepper/mode_build.py
+++ b/immunopepper/mode_build.py
@@ -341,7 +341,6 @@ def mode_build(arg):
     global countinfo #Will be used in non parallel mode
     global genetable #Will be used in non parallel mode
     global kmer_database #Will be used in non parallel mode
-    #mp.set_start_method("spawn")
     # read and process the annotation file
     logging.info(">>>>>>>>> Build: Start Preprocessing")
     logging.info('Building lookup structure ...')
@@ -459,7 +458,7 @@ def mode_build(arg):
             if (not arg.skip_annotation) and not (arg.libsize_extract):
                 # Build the background
                 logging.info(">>>>>>>>> Start Background processing")
-                with mp.get_context("spawn").Pool(processes=arg.parallel, initializer=pool_initializer_glob, initargs=(countinfo, genetable, kmer_database)) as pool:
+                with ThreadPool(processes=None, initializer=pool_initializer_glob, initargs=(countinfo, genetable, kmer_database)) as pool:
                     args = [(output_sample, arg.mutation_sample,  graph_data[gene_idx], gene_idx, n_genes, mutation,
                              countinfo, genetable, arg,
                              os.path.join(output_path, f'tmp_out_{mutation.mode}_batch_{i + arg.start_id}'),

--- a/immunopepper/mode_build.py
+++ b/immunopepper/mode_build.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import h5py
 import logging
 import multiprocessing as mp
+from multiprocessing.pool import ThreadPool
 import numpy as np
 import os
 import pathlib
@@ -61,7 +62,7 @@ def pool_initializer_glob(countinfo_glob, genetable_glob, kmer_database_glob): #
     countinfo = countinfo_glob
     genetable = genetable_glob
     kmer_database = kmer_database_glob
-    return sig.signal(sig.SIGINT, sig.SIG_IGN)
+    #return sig.signal(sig.SIGINT, sig.SIG_IGN)
 
 def mapper_funct(tuple_arg):
     process_gene_batch_foreground(*tuple_arg)
@@ -340,7 +341,8 @@ def mode_build(arg):
     global countinfo #Will be used in non parallel mode
     global genetable #Will be used in non parallel mode
     global kmer_database #Will be used in non parallel mode
-    mp.set_start_method("spawn")
+    #mp.set_start_method("spawn")
+    logging.info("NO SPAWN")
     # read and process the annotation file
     logging.info(">>>>>>>>> Build: Start Preprocessing")
     logging.info('Building lookup structure ...')
@@ -468,7 +470,7 @@ def mode_build(arg):
 
             # Build the foreground
             logging.info(">>>>>>>>> Start Foreground processing")
-            with mp.Pool(processes=arg.parallel, initializer=pool_initializer_glob, initargs=(countinfo, genetable, kmer_database)) as pool:
+            with ThreadPool(processes=None, initializer=pool_initializer_glob, initargs=(countinfo, genetable, kmer_database)) as pool:
                 args = [(output_sample, arg.mutation_sample, output_samples_ids, graph_data[gene_idx],
                          graph_info[gene_idx], gene_idx, n_genes, genes_interest, disable_process_libsize,
                          arg.all_read_frames, complexity_cap, mutation, junction_dict, arg,

--- a/immunopepper/mode_build.py
+++ b/immunopepper/mode_build.py
@@ -342,7 +342,6 @@ def mode_build(arg):
     global genetable #Will be used in non parallel mode
     global kmer_database #Will be used in non parallel mode
     #mp.set_start_method("spawn")
-    logging.info("NO SPAWN")
     # read and process the annotation file
     logging.info(">>>>>>>>> Build: Start Preprocessing")
     logging.info('Building lookup structure ...')

--- a/immunopepper/mode_build.py
+++ b/immunopepper/mode_build.py
@@ -384,7 +384,7 @@ def mode_build(arg):
 
     ### DEBUG
     #graph_data = graph_data[[3170]] #TODO remove
-    graph_data = graph_data[940:942]
+    #graph_data = graph_data[940:942]
     if arg.start_id != 0 and arg.start_id < len(graph_data):
         logging.info(f'development feature: starting at gene number {arg.start_id}')
         graph_data = graph_data[arg.start_id:]

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -362,8 +362,8 @@ def get_and_write_peptide_and_kmer(peptide_set=None, kmer_dict=None,
 
         if not gene.splicegraph.edges is None:
             gene.to_sparse()
-    if cross_graph_expr:
-        save_kmer_matrix(kmer_matrix_edge, kmer_matrix_segm, graph_samples, filepointer,
+    if cross_graph_expr: # Only one kmer length supported for this mode
+        save_kmer_matrix(kmer_matrix_edge, kmer_matrix_segm, kmer[0], graph_samples, filepointer,
                          compression=None, out_dir=out_dir, verbose=verbose_save)
 
 

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -605,13 +605,13 @@ def create_output_kmer_cross_samples(output_peptide, k, segm_expr_list, graph_ou
                 kmer_matrix_segm.add(tuple(row_metadata + list(np.round(sublist_seg, 2))))
                 logging.info(f'.........End Segm Add tuple')
 
-                if len(kmer_matrix_segm) > 1000: # small but dense
+                if len(kmer_matrix_segm) > 1000000: # small but dense
                     logging.info(f"Start save kmer SEGMENT with len {len(kmer_matrix_segm) } matrix INTERM to {out_dir}..")
                     save_kmer_matrix(None, kmer_matrix_segm, k, graph_samples, filepointer,
                                      compression, out_dir, verbose)
                     kmer_matrix_segm.clear()
                     logging.info(f'Cleared len {len(kmer_matrix_segm)}')
-                if len(kmer_matrix_edge) > 1000: # big but relatively sparse
+                if len(kmer_matrix_edge) > 1000000: # big but relatively sparse
                     logging.info( f"Start save kmer EDGE with len {len(kmer_matrix_edge) } matrix INTERM to {out_dir}..")
                     save_kmer_matrix(kmer_matrix_edge, None, k, graph_samples, filepointer,
                                      compression, out_dir, verbose)

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -1,5 +1,4 @@
 """Contains all the output computation based on gene splicegraph"""
-import logging
 from collections import defaultdict
 import numpy as np
 
@@ -543,7 +542,6 @@ def create_output_kmer_cross_samples(output_peptide, k, segm_expr_list, graph_ou
     else:
         spanning_index1, spanning_index2, spanning_index1_2 = [np.nan], [np.nan], [np.nan]
 
-    logging.info(f'Len output peptide {len(output_peptide.peptide)}')
     if len(output_peptide.peptide) >= k:
         for j in range(len(output_peptide.peptide) - k + 1):
             kmer_peptide = output_peptide.peptide[j:j+k]
@@ -596,27 +594,18 @@ def create_output_kmer_cross_samples(output_peptide, k, segm_expr_list, graph_ou
                 W_past = W
             # update the cross samples matrix
             if check_database:
-                logging.info(f'Respective length of Edge, segment tuples {len(kmer_matrix_edge)}, {len(kmer_matrix_segm)}')
                 row_metadata = [kmer_peptide, is_in_junction, junction_annotated, output_peptide.read_frame_annotated]
-                logging.info(f'.........Start Edge Add tuple')
                 kmer_matrix_edge.add(tuple(row_metadata + list(sublist_jun)))
-                logging.info(f'.........End Edge Add tuple')
-                logging.info(f'.........Start Segm Add tuple')
                 kmer_matrix_segm.add(tuple(row_metadata + list(np.round(sublist_seg, 2))))
-                logging.info(f'.........End Segm Add tuple')
 
                 if len(kmer_matrix_segm) > 1000000: # small but dense
-                    logging.info(f"Start save kmer SEGMENT with len {len(kmer_matrix_segm) } matrix INTERM to {out_dir}..")
                     save_kmer_matrix(None, kmer_matrix_segm, k, graph_samples, filepointer,
                                      compression, out_dir, verbose)
                     kmer_matrix_segm.clear()
-                    logging.info(f'Cleared len {len(kmer_matrix_segm)}')
                 if len(kmer_matrix_edge) > 1000000: # big but relatively sparse
-                    logging.info( f"Start save kmer EDGE with len {len(kmer_matrix_edge) } matrix INTERM to {out_dir}..")
                     save_kmer_matrix(kmer_matrix_edge, None, k, graph_samples, filepointer,
                                      compression, out_dir, verbose)
                     kmer_matrix_edge.clear()
-                    logging.info(f'Cleared len {len(kmer_matrix_edge)}')
 
 
 

--- a/immunopepper/utils.py
+++ b/immunopepper/utils.py
@@ -344,11 +344,18 @@ def create_libsize(expr_distr_fp, output_fp, sample, debug=False):
     libsize_exists = ''
     sample_expr_distr = pa.parquet.read_table(expr_distr_fp['path']).to_pandas()
 
-    libsize_count = pd.DataFrame({'sample': sample_expr_distr.columns[1:],
+    # change types
+    convert_dict = {}
+    for col in sample_expr_distr.columns:
+        if col != 'gene':
+            convert_dict[col] = float
+    sample_expr_distr = sample_expr_distr.astype(convert_dict)
+
+    # compute libsizes
+    df_libsize = pd.DataFrame({'sample': sample_expr_distr.columns[1:],
                                  'libsize_75percent': np.percentile(sample_expr_distr.iloc[:, 1:], 75, axis=0, interpolation='linear'),
                                   'libsize_total_count': np.sum(sample_expr_distr.iloc[:, 1:], axis=0)}, index = None)
 
-    df_libsize = pd.DataFrame(libsize_count)
 
     if os.path.isfile(output_fp):
         previous_libsize = pd.read_csv(output_fp, sep = '\t')


### PR DESCRIPTION
This branch implements small changes which should make the computation more lightweight:

1. Replace pandas dataframes by numpy arrays. This improves computing speed.
2. Kmers are not saved for each gene but dumped to disk after reaching a certain number of lines. This number can differ for the edge and segment expression matrix. All the kmers of a minibatch are unique instances (kmer, expression) before the saving operation. This helps to avoid out-of-memory errors. 
3. Chunks are saved to independent partitions. The file-pointers are not left open anymore because parquet is a column-oriented format. This helps with speed. 
4. The Multiprocessing pool of cores is replaced by a pool of threads. This helps reduce the memory used by the software and has no influence on the speed. 