### PR TITLE
Fix/postpone expression extraction

### DIFF
--- a/immunopepper/filter.py
+++ b/immunopepper/filter.py
@@ -89,9 +89,9 @@ def filter_redundant_junctions(vertex_pairs: list[VertexPair], strand: str):
     return list(filter(lambda m: m.output_id not in remove_id_list, vertex_pairs))
 
 
-def junction_is_annotated(gene: Gene, gene_to_transcript_table: dict[str: list[str]],
+def junctions_annotated(gene: Gene, gene_to_transcript_table: dict[str: list[str]],
                           transcript_to_cds_table: dict[str: list[tuple[int, int, int]]]):
-    """ Indicates whether a junction also appears in any transcript given by .gtf file
+    """Get exhaustive list of junctions appearing in any transcript given by .gtf file
 
     :param gene: :class:`Gene` instance created by Spladder
     :param gene_to_transcript_table: maps gene to its transcripts, e.g.

--- a/immunopepper/filter.py
+++ b/immunopepper/filter.py
@@ -114,7 +114,7 @@ def junctions_annotated(gene: Gene, gene_to_transcript_table: dict[str: list[str
         if len(curr_ts) < 2:
             continue
         curr_ts = np.array(curr_ts)[:, [0, 1]]
-        # create a list of pairs that join the end of a transcript to the beginning of the next transcript
+        # collect junctions coordinates for the current transcript 
         gene_annot_jx.update([':'.join(x) for x in
                                 curr_ts.ravel()[1:-1].reshape(curr_ts.shape[0] - 1, 2).astype('str')])
 

--- a/immunopepper/io_.py
+++ b/immunopepper/io_.py
@@ -271,38 +271,27 @@ def _output_info(path, file_columns, kmer_lengths=None, pq_writer=False):
     return file_info
 
 
-def disk_writer(sleep_time, path, data_iterable, columns, filepointer=None, writer_close=True, is_2d=False):
-    """Try write and catch errors"""
-    try:
-        delim = '\t'
-        linet = '\n'
-        # Open
-        if filepointer is None:
-            filepointer = gzip.open(path, 'wt')
-            filepointer.write(delim.join(columns) + linet)
+def disk_writer(path, data_iterable, columns, filepointer=None, writer_close=True, is_2d=False):
+    """Write gzip to disk"""
+    delim = '\t'
+    linet = '\n'
+    # Open
+    if filepointer is None:
+        filepointer = gzip.open(path, 'wt')
+        filepointer.write(delim.join(columns) + linet)
 
-        # Write
-        if is_2d:
-            for idx, line in enumerate(data_iterable):
-                filepointer.write(delim.join([str(x) for x in line]) + linet)
-        else:
-            for line in data_iterable:
-                filepointer.write(line + '\n')
+    # Write
+    if is_2d:
+        for idx, line in enumerate(data_iterable):
+	    filepointer.write(delim.join([str(x) for x in line]) + linet)
+    else:
+	for line in data_iterable:
+	    filepointer.write(line + '\n')
 
-        # Close
-        if writer_close:
-            filepointer.close()
-            filepointer = None
-
-        error_encountered = 0
-
-    except OSError:
-        logging.info(f'Issue saving {path} to file system: sleeping {sleep_time} sec.')
-        sleep(sleep_time)
-        error_encountered = 1
-        logging.info(f'IO Error: Sleeping {sleep_time} seconds and retry.')
-
-    return error_encountered
+    # Close
+    if writer_close:
+        filepointer.close()
+        filepointer = None
 
 
 def save_to_gzip(path, data_iterable, columns, verbose=False, filepointer=None, writer_close=True, is_2d=False):
@@ -314,8 +303,15 @@ def save_to_gzip(path, data_iterable, columns, verbose=False, filepointer=None, 
     error_encountered = 1
     sleep_times = [60, 10, 1]  # Number of seconds for each saving attempt
     while sleep_times and error_encountered:
-        error_encountered = disk_writer(sleep_times.pop(), path, data_iterable, columns,
-                                                  filepointer, writer_close, is_2d)
+        try:
+            disk_writer(path, data_iterable, columns, filepointer, writer_close, is_2d)
+            error_encountered = 0
+        except OSError:
+            sleep_time = sleep_times.pop()
+	    logging.info(f'Issue saving {path} to file system: sleeping {sleep_time} sec. and retry')
+	    sleep(sleep_time)
+	    error_encountered = 1
+ 
     if error_encountered:
         raise OSError('Issue with saving device')
 

--- a/immunopepper/io_.py
+++ b/immunopepper/io_.py
@@ -284,10 +284,10 @@ def disk_writer(path, data_iterable, columns, filepointer=None, writer_close=Tru
     # Write
     if is_2d:
         for idx, line in enumerate(data_iterable):
-	    filepointer.write(delim.join([str(x) for x in line]) + linet)
+            filepointer.write(delim.join([str(x) for x in line]) + linet)
     else:
-	for line in data_iterable:
-	    filepointer.write(line + '\n')
+        for line in data_iterable:
+            filepointer.write(line + '\n')
 
     # Close
     if writer_close:
@@ -309,9 +309,9 @@ def save_to_gzip(path, data_iterable, columns, verbose=False, filepointer=None, 
             error_encountered = 0
         except OSError:
             sleep_time = sleep_times.pop()
-	    logging.info(f'Issue saving {path} to file system: sleeping {sleep_time} sec. and retry')
-	    sleep(sleep_time)
-	    error_encountered = 1
+            logging.info(f'Issue saving {path} to file system: sleeping {sleep_time} sec. and retry')
+            sleep(sleep_time)
+            error_encountered = 1
  
     if error_encountered:
         raise OSError('Issue with saving device')
@@ -334,17 +334,15 @@ def collect_results(filepointer_item, out_dir, mutation_mode, partitions=False):
     file_name = os.path.basename(file_path)
     # adjust name for partitions
     if partitions:
-	tmp_file_list = glob.glob(os.path.join(out_dir, f'tmp_out_{mutation_mode}_batch_[0-9]*',
-					       file_name, '*part*'))
+        tmp_file_list = glob.glob(os.path.join(out_dir, f'tmp_out_{mutation_mode}_batch_[0-9]*', file_name, '*part*'))
     else:
-	tmp_file_list = glob.glob(os.path.join(out_dir, f'tmp_out_{mutation_mode}_batch_[0-9]*',
-					       file_name))
+        tmp_file_list = glob.glob(os.path.join(out_dir, f'tmp_out_{mutation_mode}_batch_[0-9]*', file_name))
 
     try:
-	df = pd.concat((pd.read_csv(f, sep='\t', compression='gzip') for f in tmp_file_list), ignore_index=True)
+        df = pd.concat((pd.read_csv(f, sep='\t', compression='gzip') for f in tmp_file_list), ignore_index=True)
     except:
-	logging.error(f'Unable to read one of files for {file_path} collection')
-	sys.exit(1)
+        logging.error(f'Unable to read one of files for {file_path} collection')
+        sys.exit(1)
     return df
 
 

--- a/immunopepper/io_.py
+++ b/immunopepper/io_.py
@@ -241,7 +241,7 @@ def initialize_fp(output_path: str, mutation_mode: str,
                                 'originalExonsCoord', 'vertexIdx', 'junctionExpr', 'segmentExpr',
                                 'kmerType']
     cols_pep_file = ['fasta']
-    cols_metaOnly_kmer_cross_sample_file = ['kmer', 'coord', 'isCrossJunction', 'junctionAnnotated', 'readFrameAnnotated']
+    metacols_kmers_expr_file = ['kmer', 'coord', 'isCrossJunction', 'junctionAnnotated', 'readFrameAnnotated']
 
     # --- Grouping dict
     if output_fasta:  # Foreground peptide fasta - optional
@@ -249,8 +249,8 @@ def initialize_fp(output_path: str, mutation_mode: str,
     else:
         peptide_fp = None
 
-    kmer_segm_expr_fp = _output_info(graph_kmer_segment_expr_path, cols_metaOnly_kmer_cross_sample_file, pq_writer=True)
-    kmer_edge_expr_fp = _output_info(graph_kmer_junction_expr_path, cols_metaOnly_kmer_cross_sample_file, pq_writer=True)
+    kmer_segm_expr_fp = _output_info(graph_kmer_segment_expr_path, metacols_kmers_expr_file, pq_writer=True)
+    kmer_edge_expr_fp = _output_info(graph_kmer_junction_expr_path, metacols_kmers_expr_file, pq_writer=True)
 
     metadata_fp = _output_info(junction_meta_file_path, cols_metadata_file)
     annot_fp = _output_info(annot_peptide_file_path, cols_annot_pep_file)

--- a/immunopepper/io_.py
+++ b/immunopepper/io_.py
@@ -247,7 +247,7 @@ def initialize_fp(output_path: str, mutation_mode: str,
     cols_pep_file = ['fasta']
     cols_kmer_single_sample_file = ['kmer', 'id', 'segmentExpr', 'isCrossJunction', 'junctionExpr',
                                'junctionAnnotated', 'readFrameAnnotated']
-    cols_metaOnly_kmer_cross_sample_file = ['kmer', 'isCrossJunction', 'junctionAnnotated', 'readFrameAnnotated']
+    cols_metaOnly_kmer_cross_sample_file = ['kmer', 'coord', 'isCrossJunction', 'junctionAnnotated', 'readFrameAnnotated']
 
     # --- Grouping dict
     if output_fasta:  # Foreground peptide fasta - optional

--- a/immunopepper/ip.py
+++ b/immunopepper/ip.py
@@ -35,7 +35,6 @@ def parse_arguments(argv):
     submodes.add_argument("--all-read-frames", help="switch from annotated reading frames to exhaustive translation", action="store_true", required=False, default=False)
     submodes.add_argument("--count-path", help="absolute path of count hdf5 file. If not provided candidates are output without expression quantification", required=False, default=None)
     submodes.add_argument("--output-samples", nargs='+', help="list of sample names to output, names must match the graph samples. If not provided, all count samples will be output (runs faster)", required=False, default=[])
-    submodes.add_argument("--cross-graph-expr", help="switches from per sample edge + segment expression files to edge (resp segment) expression matrices [kmer/peptides x samples]", action="store_true", required=False, default=False)
     submodes.add_argument("--heter-code", type=int, help=argparse.SUPPRESS, default=0) # if count expression data is provided in h5 format, specify the code for heterzygous
 
     parameters = parser_build.add_argument_group('TECHNICAL PARAMETERS: Parameters to dump intermediate data or to optimize processing')

--- a/immunopepper/ip.py
+++ b/immunopepper/ip.py
@@ -28,7 +28,7 @@ def parse_arguments(argv):
     required.add_argument("--ann-path", help="absolute path of reference gene annotation file", required=True)
     required.add_argument("--splice-path", help="absolute path of splicegraph file", required=True)
     required.add_argument("--ref-path", help="absolute path of reference genome file", required=True)
-    required.add_argument("--kmer", nargs='+', type=int, help="list which specifies the different k for kmer output", required=True, default=[])
+    required.add_argument("--kmer", type=int, help="specifies the desired kmer length output", required=True, default=9)
 
     submodes = parser_build.add_argument_group('SUBMODES PROCESS: Conceptual choices about the processing required')
     submodes.add_argument("--libsize-extract", help="goes through the graph only to output gene quantifications and library sizes. Skips neoepitope generation", action="store_true", required=False, default=False)

--- a/immunopepper/mode_build.py
+++ b/immunopepper/mode_build.py
@@ -449,21 +449,9 @@ def mode_build(arg):
                 exits_if_exception = [res for res in result]
 
 
-            # Collects and pools the files of each batch
-            logging.info("Start collecting results")
-            if countinfo:
-                collect_results(filepointer.gene_expr_fp, output_path, pq_compression, mutation.mode)
-            if arg.output_fasta:
-                collect_results(filepointer.junction_peptide_fp, output_path, pq_compression, mutation.mode)
-            collect_results(filepointer.background_peptide_fp, output_path, pq_compression, mutation.mode)
-            collect_results(filepointer.junction_meta_fp, output_path, pq_compression, mutation.mode)
-            collect_results(filepointer.junction_kmer_fp, output_path, pq_compression, mutation.mode, arg.kmer)
-            collect_results(filepointer.background_kmer_fp, output_path, pq_compression, mutation.mode, arg.kmer)
-            collect_results(filepointer.kmer_segm_expr_fp, output_path, pq_compression,
-                            mutation.mode, parquet_partitions=True)
-            collect_results(filepointer.kmer_edge_expr_fp, output_path, pq_compression,
-                            mutation.mode, parquet_partitions=True)
-            if not arg.keep_tmpfiles:
+            logging.info("Finished traversal")
+
+            if not arg.keep_tmpfiles: #TODO update
                 logging.info("Cleaning temporary files")
                 remove_folder_list(os.path.join(output_path, f'tmp_out_{mutation.mode}_batch'))
 
@@ -484,7 +472,7 @@ def mode_build(arg):
                                            verbose=True)
 
         if (not disable_process_libsize) and countinfo:
-            create_libsize(filepointer.gene_expr_fp, output_libsize_fp, output_sample)
+            create_libsize(filepointer.gene_expr_fp, output_libsize_fp, output_path, mutation.mode, arg.parallel)
 
 
 

--- a/immunopepper/mode_build.py
+++ b/immunopepper/mode_build.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import h5py
 import logging
 import multiprocessing as mp
+from multiprocessing.pool import Pool
 from multiprocessing.pool import ThreadPool
 import numpy as np
 import os
@@ -439,7 +440,7 @@ def mode_build(arg):
 
             # Build the foreground
             logging.info(">>>>>>>>> Start Foreground processing")
-            with ThreadPool(processes=None, initializer=pool_initializer_glob, initargs=(countinfo, genetable, kmer_database)) as pool:
+            with Pool(processes=None, initializer=pool_initializer_glob, initargs=(countinfo, genetable, kmer_database)) as pool:
                 args = [(output_sample, arg.mutation_sample, output_samples_ids, graph_data[gene_idx],
                          graph_info[gene_idx], gene_idx, n_genes, genes_interest, disable_process_libsize,
                          arg.all_read_frames, complexity_cap, mutation, junction_dict, arg,

--- a/immunopepper/mode_build.py
+++ b/immunopepper/mode_build.py
@@ -72,7 +72,7 @@ def mapper_funct_back(tuple_arg):
     process_gene_batch_background(*tuple_arg)
 
 
-def process_gene_batch_background(output_sample, mutation_sample, genes, gene_idxs, n_genes, mutation, countinfo_b,
+def process_gene_batch_background(output_sample, mutation_sample, genes, gene_idxs, n_genes, mutation,
                                   genetable, arg, outbase, filepointer, verbose=False):
     if arg.parallel > 1:
         batch_name = int(outbase.split('/')[-1].split('_')[-1])
@@ -81,8 +81,8 @@ def process_gene_batch_background(output_sample, mutation_sample, genes, gene_id
 
     if (arg.parallel==1) or (not os.path.exists(os.path.join(outbase, "Annot_IS_SUCCESS"))):
         pathlib.Path(outbase).mkdir(exist_ok=True, parents=True)
-        set_kmer_back =  defaultdict(set, {})
         set_pept_backgrd = set()
+        set_kmer_backgrd = set()
         time_per_gene = []
         mem_per_gene = []
         all_gene_idxs = []
@@ -96,7 +96,6 @@ def process_gene_batch_background(output_sample, mutation_sample, genes, gene_id
                     gene.name not in genetable.gene_to_ts):
                 continue
 
-            idx = get_idx(countinfo_b, output_sample, gene_idxs[i])
             all_gene_idxs.append(gene_idxs[i])
 
             chrm = gene.chr.strip()
@@ -104,26 +103,13 @@ def process_gene_batch_background(output_sample, mutation_sample, genes, gene_id
             ref_mut_seq = collect_background_transcripts(gene=gene, ref_seq_file=arg.ref_path,
                                                          chrm=chrm, mutation=sub_mutation)
 
-            # Gene counts information
-            if arg.cross_graph_expr:
-                countinfo_b = None
-            if countinfo_b:
-                gidx = countinfo_b.gene_idx_dict[gene.name]
-                count_segments = np.arange(countinfo_b.gene_id_to_segrange[gidx][0],
-                                           countinfo_b.gene_id_to_segrange[gidx][1])
-                with h5py.File(countinfo_b.h5fname, 'r') as h5f:
-                    seg_counts = h5f['segments'][count_segments, idx.sample]
-            else:
-                seg_counts = None
 
-            get_and_write_background_peptide_and_kmer(peptide_set = set_pept_backgrd,
-                                                      kmer_dict = set_kmer_back,
+            get_and_write_background_peptide_and_kmer(peptide_set=set_pept_backgrd,
+                                                      kmer_set=set_kmer_backgrd,
                                                       gene=gene,
                                                       ref_mut_seq=ref_mut_seq,
                                                        gene_table=genetable,
-                                                       countinfo=countinfo_b,
-                                                       seg_counts=seg_counts,
-                                                       Idx=idx,
+                                                       countinfo=None,
                                                        kmer=arg.kmer,
                                                        all_read_frames=arg.all_read_frames)
 
@@ -132,9 +118,8 @@ def process_gene_batch_background(output_sample, mutation_sample, genes, gene_id
 
         save_bg_peptide_set(set_pept_backgrd, filepointer, outbase, verbose)
         set_pept_backgrd.clear()
-        for kmer_length in set_kmer_back:
-            save_bg_kmer_set(set_kmer_back[kmer_length], filepointer, kmer_length, outbase, verbose)
-        set_kmer_back.clear()
+        save_bg_kmer_set(set_kmer_backgrd, filepointer, outbase, verbose)
+        set_kmer_backgrd.clear()
 
         pathlib.Path(os.path.join(outbase, "Annot_IS_SUCCESS")).touch()
 
@@ -172,7 +157,6 @@ def process_gene_batch_foreground(output_sample, mutation_sample, output_samples
 
     if (arg.parallel==1) or (not os.path.exists(os.path.join(outbase, "output_sample_IS_SUCCESS"))):
         pathlib.Path(outbase).mkdir(exist_ok=True, parents=True)
-        dictofSets_kmer_foregr = defaultdict(set, {})
         set_pept_forgrd = set()
         time_per_gene = []
         mem_per_gene = []
@@ -206,21 +190,16 @@ def process_gene_batch_foreground(output_sample, mutation_sample, output_samples
                                 edge_gene_idxs = np.arange(countinfo.gene_id_to_edgerange[gidx][0],
                                                            countinfo.gene_id_to_edgerange[gidx][1])
                                 edge_idxs = h5f['edge_idx'][list(edge_gene_idxs)].astype('int')
-                                if arg.cross_graph_expr:
-                                    edge_counts = h5f['edges'][edge_gene_idxs,:] # will compute expression on whole graph
-                                else:
-                                    edge_counts = h5f['edges'][edge_gene_idxs,idx.sample]
+                                edge_counts = h5f['edges'][edge_gene_idxs,:] # will compute expression on whole graph
+
                             # Get segment counts
                             seg_gene_idxs = np.arange(countinfo.gene_id_to_segrange[gidx][0],
                                                       countinfo.gene_id_to_segrange[gidx][1])
-                            if arg.cross_graph_expr:
-                                seg_counts = h5f['segments'][seg_gene_idxs, :]
-                                if output_samples_ids is not None:
-                                    seg_counts = seg_counts[:, output_samples_ids] # limitation fancy hdf5 indexing
-                                else:
-                                    output_samples_ids = np.arange(seg_counts.shape[1])
+                            seg_counts = h5f['segments'][seg_gene_idxs, :]
+                            if output_samples_ids is not None:
+                                seg_counts = seg_counts[:, output_samples_ids] # limitation fancy hdf5 indexing
                             else:
-                                seg_counts = h5f['segments'][seg_gene_idxs, idx.sample]
+                                output_samples_ids = np.arange(seg_counts.shape[1])
                 else:
                     edge_idxs = None
                     edge_counts = None
@@ -228,8 +207,7 @@ def process_gene_batch_foreground(output_sample, mutation_sample, output_samples
 
             # library size calculated only for genes with CDS
             if (gene.name in genetable.gene_to_cds_begin) and (gene.name in genetable.gene_to_ts) and countinfo:
-                gene_expr.append([gene.name] + get_total_gene_expr(gene, countinfo, idx,
-                                                                   seg_counts, arg.cross_graph_expr))
+                gene_expr.append([gene.name] + get_total_gene_expr(gene, countinfo, seg_counts))
 
             # Process only gene quantifications and libsizes
             if arg.libsize_extract:
@@ -248,7 +226,7 @@ def process_gene_batch_foreground(output_sample, mutation_sample, output_samples
 
             chrm = gene.chr.strip()
             sub_mutation = get_sub_mutations(mutation, mutation_sample, chrm)
-            if (arg.mutation_sample is not None) and (arg.cross_graph_expr):
+            if (arg.mutation_sample is not None):
                 mut_count_id = [idx for idx, sample in enumerate(arg.output_samples)
                                 if arg.mutation_sample.replace('-', '').replace('_', '').replace('.', '').replace('/', '') == sample][0]
             else:
@@ -257,9 +235,8 @@ def process_gene_batch_foreground(output_sample, mutation_sample, output_samples
             if not junction_dict is None and chrm in junction_dict:
                 junction_list = junction_dict[chrm]
  
-            if arg.cross_graph_expr:
-                pathlib.Path(get_save_path(filepointer.kmer_segm_expr_fp, outbase)).mkdir(exist_ok=True, parents=True)
-                pathlib.Path(get_save_path(filepointer.kmer_edge_expr_fp, outbase)).mkdir(exist_ok=True, parents=True)
+            pathlib.Path(get_save_path(filepointer.kmer_segm_expr_fp, outbase)).mkdir(exist_ok=True, parents=True)
+            pathlib.Path(get_save_path(filepointer.kmer_edge_expr_fp, outbase)).mkdir(exist_ok=True, parents=True)
             vertex_pairs, \
             ref_mut_seq, \
             exon_som_dict = collect_vertex_pairs(gene=gene,
@@ -274,7 +251,6 @@ def process_gene_batch_foreground(output_sample, mutation_sample, output_samples
                                                  filter_redundant=arg.filter_redundant)
 
             get_and_write_peptide_and_kmer(peptide_set=set_pept_forgrd,
-                                            kmer_dict = dictofSets_kmer_foregr,
                                             gene=gene,
                                             all_vertex_pairs=vertex_pairs,
                                             ref_mut_seq=ref_mut_seq,
@@ -293,7 +269,6 @@ def process_gene_batch_foreground(output_sample, mutation_sample, output_samples
                                             edge_idxs=edge_idxs,
                                             edge_counts=edge_counts,
                                             seg_counts=seg_counts,
-                                            cross_graph_expr=arg.cross_graph_expr,
                                             all_read_frames=arg.all_read_frames,
                                             filepointer=filepointer,
                                             graph_output_samples_ids = output_samples_ids,
@@ -309,10 +284,6 @@ def process_gene_batch_foreground(output_sample, mutation_sample, output_samples
         save_gene_expr_distr(gene_expr, arg.output_samples, output_sample,  filepointer, outbase, verbose)
         save_fg_peptide_set(set_pept_forgrd, filepointer, outbase, arg.output_fasta, verbose)
         set_pept_forgrd.clear()
-        if not arg.cross_graph_expr: # Write kmer file for single sample (multiple kmer lengths supported)
-            for kmer_length in arg.kmer:
-                save_fg_kmer_dict(dictofSets_kmer_foregr[kmer_length], filepointer, kmer_length, outbase, verbose)
-            dictofSets_kmer_foregr.clear()
 
         pathlib.Path(os.path.join(outbase, "output_sample_IS_SUCCESS")).touch()
 
@@ -355,8 +326,8 @@ def mode_build(arg):
     if arg.count_path is not None:
         logging.info('Loading count data ...')
         countinfo, matching_count_samples, matching_count_ids  = parse_gene_metadata_info(arg.count_path,
-                                                                                          arg.output_samples,
-                                                                                          arg.cross_graph_expr)
+                                                                                          arg.output_samples)
+
 
         end_time = timeit.default_timer()
         logging.info('\tTime spent: {:.3f} seconds'.format(end_time - start_time))
@@ -437,13 +408,13 @@ def mode_build(arg):
 
         if not os.path.isdir(output_path):
             os.makedirs(output_path)
-        gzip_tag = ''
+        gzip_tag = '' #TODO clean next commit
         if arg.compressed:
             pq_compression = 'SNAPPY'
         else:
             pq_compression = None
         filepointer = initialize_fp(output_path, mutation.mode,
-                  arg.kmer, arg.output_fasta, arg.cross_graph_expr)
+                  arg.kmer, arg.output_fasta)
 
         # go over each gene in splicegraph
         genes_range = list(range(0, n_genes))
@@ -460,7 +431,7 @@ def mode_build(arg):
                 logging.info(">>>>>>>>> Start Background processing")
                 with ThreadPool(processes=None, initializer=pool_initializer_glob, initargs=(countinfo, genetable, kmer_database)) as pool:
                     args = [(output_sample, arg.mutation_sample,  graph_data[gene_idx], gene_idx, n_genes, mutation,
-                             countinfo, genetable, arg,
+                             genetable, arg,
                              os.path.join(output_path, f'tmp_out_{mutation.mode}_batch_{i + arg.start_id}'),
                              filepointer, verbose_save) for i, gene_idx in gene_batches ]
                     result = pool.imap(mapper_funct_back, args, chunksize=1)
@@ -502,7 +473,7 @@ def mode_build(arg):
             logging.info(">>>>>>>>> Start Background processing")
             if (not arg.skip_annotation) and not (arg.libsize_extract):
                 process_gene_batch_background(output_sample, arg.mutation_sample, graph_data, genes_range, n_genes,
-                                              mutation, countinfo, genetable, arg, output_path, filepointer,
+                                              mutation, genetable, arg, output_path, filepointer,
                                               verbose=True)
             # Build the foreground and remove the background if needed
             logging.info(">>>>>>>>> Start Foreground processing")

--- a/immunopepper/mode_build.py
+++ b/immunopepper/mode_build.py
@@ -109,10 +109,10 @@ def process_gene_batch_background(output_sample, mutation_sample, genes, gene_id
                                                       kmer_set=set_kmer_backgrd,
                                                       gene=gene,
                                                       ref_mut_seq=ref_mut_seq,
-                                                       gene_table=genetable,
-                                                       countinfo=None,
-                                                       kmer=arg.kmer,
-                                                       all_read_frames=arg.all_read_frames)
+                                                      gene_table=genetable,
+                                                      countinfo=None,
+                                                      kmer_length=arg.kmer,
+                                                      all_read_frames=arg.all_read_frames)
 
             time_per_gene.append(timeit.default_timer() - start_time)
             mem_per_gene.append(print_memory_diags(disable_print=True))
@@ -248,7 +248,7 @@ def process_gene_batch_foreground(output_sample, mutation_sample, output_samples
                                                  mutation=sub_mutation,
                                                  all_read_frames=all_read_frames,
                                                  disable_concat=arg.disable_concat,
-                                                 kmer=arg.kmer,
+                                                 kmer_length=arg.kmer,
                                                  filter_redundant=arg.filter_redundant)
 
             get_and_write_peptide_and_kmer(peptide_set=set_pept_forgrd,
@@ -414,8 +414,7 @@ def mode_build(arg):
             pq_compression = 'SNAPPY'
         else:
             pq_compression = None
-        filepointer = initialize_fp(output_path, mutation.mode,
-                  arg.kmer, arg.output_fasta)
+        filepointer = initialize_fp(output_path, mutation.mode, arg.output_fasta)
 
         # go over each gene in splicegraph
         genes_range = list(range(0, n_genes))

--- a/immunopepper/namedtuples.py
+++ b/immunopepper/namedtuples.py
@@ -18,12 +18,13 @@ Output_junc_peptide namedtuple
 - junction_id is the index of given junction pair in all junction pair (in descending or ascending order)
 - peptide: (peptide_string). The peptide translated from junction pairs.
 - exons_coor: Coord namedtuple
+- strand: str ('+', '_'). The strand of gene.
 - junction_annotated: bool. True if the junction also appears in the input annotation file, False otherwise. 
   False if the peptide stops before the junction  
 - read_frame_annotated: bool. True if a transcript in the given reading frame is present in the annotation, 
   False if it is created by propagation
 """
-OutputPeptide = namedtuple('OutputPeptide', ['output_id', 'peptide', 'exons_coor', 'junction_expr',
+OutputPeptide = namedtuple('OutputPeptide', ['output_id', 'peptide', 'exons_coor', 'strand', 'junction_expr',
                                                      'junction_annotated', 'read_frame_annotated'])
 
 

--- a/immunopepper/namedtuples.py
+++ b/immunopepper/namedtuples.py
@@ -15,17 +15,13 @@ except:
 """
 Output_junc_peptide namedtuple
 - output_id: (gene_id).(junction_id). gene_id is the index of given gene in the splicegraph array.
-- junction_id is the index of given junction pair in all junction pair (in descending or ascending order)
 - peptide: (peptide_string). The peptide translated from junction pairs.
 - exons_coor: Coord namedtuple
 - strand: str ('+', '_'). The strand of gene.
-- junction_annotated: bool. True if the junction also appears in the input annotation file, False otherwise. 
-  False if the peptide stops before the junction  
 - read_frame_annotated: bool. True if a transcript in the given reading frame is present in the annotation, 
   False if it is created by propagation
 """
-OutputPeptide = namedtuple('OutputPeptide', ['output_id', 'peptide', 'exons_coor', 'strand', 'junction_expr',
-                                                     'junction_annotated', 'read_frame_annotated'])
+OutputPeptide = namedtuple('OutputPeptide', ['output_id', 'peptide', 'exons_coor', 'strand', 'read_frame_annotated'])
 
 
 """
@@ -39,8 +35,6 @@ Output_metadata namedtuple.
 - gene_chr: str. The Chromosome id where the gene is located.
 - gene_strand: str ('+', '_'). The strand of gene.
 - mutation_mode: str ('ref', 'somatic', 'germline', 'somatic_and_germline'). Mutation mode
-- junction_annotated: bool. True if the junction also appears in the input annotation file, False otherwise.
-  False if the peptide stops before the junction
 - has_stop_codon. Boolean. Indicate if there is stop codon in the junction pair.
 - is_in_junction_list: Boolean. Indicate if the junction pair appears in the given junction whitelist
 - is_isolated: Boolean. Indicate if the output peptide is actually translated from a single exon instead of two.
@@ -53,19 +47,16 @@ Output_metadata namedtuple.
 - original_exons_coord. Coord namedtuple. Shows the original exon coordination.
 - vertex_idx. shows the vertex id of the given junction. eg 5,6 means this junction pars consists of the fifth and
     sixth vertex.
-- junction_expr. float. The expression of the junction.
-- segment_expr. float. The weighted sum of segment expression. We split the junction into segments and compute the segment
     expression with the length-weighted-sum expression.
 - kmer_type. str indicates whether the peptide is generated from vertice_pair, or 'vertice_triplet_xmer' ie. a triplet was necessary to generate the desired kmer length
 """
 OutputMetadata = namedtuple('OutputMetadata', ['peptide', 'output_id', 'read_frame', 'read_frame_annotated',
                                                'gene_name', 'gene_chr',
                                                  'gene_strand',	'mutation_mode',
-                                                 'junction_annotated',	'has_stop_codon',
+                                                 'has_stop_codon',
                                                  'is_in_junction_list',	'is_isolated',
                                                  'variant_comb',	'variant_seg_expr',
-                                                 'modified_exons_coord','original_exons_coord',	'vertex_idx',	'junction_expr',
-                                                 'segment_expr', 'kmer_type'])
+                                                 'modified_exons_coord','original_exons_coord',	'vertex_idx', 'kmer_type'])
 
 
 VertexPair = namedtuple('VertexPair', ['output_id', 'read_frame','has_stop_codon','modified_exons_coord','original_exons_coord','vertex_idxs','peptide_weight'])

--- a/immunopepper/namedtuples.py
+++ b/immunopepper/namedtuples.py
@@ -155,8 +155,13 @@ namedtuple that contain all the file paths objects
 - kmer_segm_expr_fp:
 - kmer_edge_expr_fp:
 """
-Filepointer = namedtuple('Filepointer',['junction_peptide_fp','junction_meta_fp','background_peptide_fp','junction_kmer_fp','background_kmer_fp', 'gene_expr_fp',
-                                        'kmer_segm_expr_fp', 'kmer_edge_expr_fp'])
+Filepointer = namedtuple('Filepointer', ['junction_peptide_fp',
+                                        'junction_meta_fp',
+                                        'background_peptide_fp',
+                                        'background_kmer_fp',
+                                         'gene_expr_fp',
+                                        'kmer_segm_expr_fp',
+                                        'kmer_edge_expr_fp'])
 
 
 

--- a/immunopepper/preprocess.py
+++ b/immunopepper/preprocess.py
@@ -281,7 +281,7 @@ def search_edge_metadata_segmentgraph(gene, coord, edge_idxs=None, edge_counts=N
             counts = np.array([edge_counts[cidx]])
         return counts
 
-    edges_res_metafile = np.nan
+    edges_res_metafile = np.nan #TODO remove this output
     segmentgraph = gene.segmentgraph
     sorted_pos = np.sort(np.array([coord.start_v1, coord.stop_v1, coord.start_v2, coord.stop_v2]))
 

--- a/immunopepper/preprocess.py
+++ b/immunopepper/preprocess.py
@@ -249,7 +249,7 @@ def attribute_item_to_dict(a_item, file_type, feature_type):
     return gtf_dict
 
 
-def search_edge_metadata_segmentgraph(gene, coord, edge_idxs=None, edge_counts=None, cross_graph_expr=None):
+def search_edge_metadata_segmentgraph(gene, coord, edge_idxs=None, edge_counts=None):
     """Given the ordered edge coordinates of the edge, return expression information of the edge
 
     Parameters
@@ -264,8 +264,7 @@ def search_edge_metadata_segmentgraph(gene, coord, edge_idxs=None, edge_counts=N
     Returns
     -------
     edges_res: tuple of floats. Expression level for the given edges.
-    edges_res_metafile: adapted value for the peptide metafile.
-    Is nan if matrix mode, because we do not report peptide expressions per sample in this mode
+    edges_res_metafile: adapted value for the peptide metafile. Will be nan.
     """
     def get_segmentgraph_edge_expr(sorted_pos, edge_idxs, edge_counts=None):
         a = np.searchsorted(segmentgraph.segments[1, :], sorted_pos[1])
@@ -294,9 +293,6 @@ def search_edge_metadata_segmentgraph(gene, coord, edge_idxs=None, edge_counts=N
         count2 = get_segmentgraph_edge_expr(sorted_pos, edge_idxs, edge_counts)
         edges_res = np.stack([count, count2])
 
-    if not cross_graph_expr:
-        edges_res = tuple(i for i in edges_res.flatten()) # TODO Back to tuple for unicity. Needs re-write of "add_peptide_properties"
-        edges_res_metafile = edges_res
 
     return edges_res_metafile, edges_res
 

--- a/immunopepper/preprocess.py
+++ b/immunopepper/preprocess.py
@@ -296,7 +296,7 @@ def search_edge_metadata_segmentgraph(gene, coord, edge_idxs=None, edge_counts=N
 
     return edges_res_metafile, edges_res
 
-def parse_gene_metadata_info(h5fname, sample_list, cross_graph_expr):
+def parse_gene_metadata_info(h5fname, sample_list):
     """ Parse the count file
 
     Parameters
@@ -354,7 +354,7 @@ def parse_gene_metadata_info(h5fname, sample_list, cross_graph_expr):
                           gene_id_to_edgerange,
                           h5fname)
     h5f.close()
-    if cross_graph_expr and sample_list:
+    if sample_list:
         # Retrieve count id matching input samples
         matching_count_ids = np.array([s_idx for input_sample in sample_list for s_idx, graph_sample in enumerate(count_names)
                                   if graph_sample.decode() == input_sample ])
@@ -646,29 +646,25 @@ def parse_gene_choices(genes_interest, process_chr, process_num, complexity_cap,
 
 def parse_output_samples_choices(arg, countinfo, matching_count_ids, matching_count_samples):
     '''handle output_sample relatively to output mode '''
-
-    if arg.cross_graph_expr:
-        if countinfo:
-            process_output_samples = ['cohort']
-            # If output samples requested, look for sample ids in count file
-            if arg.output_samples:
-                arg.output_samples = np.array(arg.output_samples)[np.argsort(matching_count_ids)]
-                arg.output_samples = [output_sample.replace('-', '').replace('_', '').replace('.', '').replace('/', '')
-                                      for output_sample in  arg.output_samples]
-                output_samples_ids = matching_count_ids[np.argsort(matching_count_ids)]
-            # If no output samples requested, take all samples in countfile
-            else:
-                arg.output_samples = [output_sample.replace('-', '').replace('_', '').replace('.', '').replace('/', '')
-                                      for output_sample in  matching_count_samples]
-                output_samples_ids = None
-        else:
-            logging.error("Count file must be specified in --cross-graph-exp mode")
-            sys.exit(1)
-    else:
+    process_output_samples = ['cohort']
+    if countinfo:
+        # If output samples requested, look for sample ids in count file
         if arg.output_samples:
-            process_output_samples = arg.output_samples
-            output_samples_ids = None
+            arg.output_samples = np.array(arg.output_samples)[np.argsort(matching_count_ids)]
+            arg.output_samples = [output_sample.replace('-', '').replace('_', '').replace('.', '').replace('/', '')
+                                  for output_sample in arg.output_samples]
+            output_samples_ids = matching_count_ids[np.argsort(matching_count_ids)]
+        # If no output samples requested, take all samples in countfile
         else:
-            logging.error("--arg.output_samples must be specified in single sample mode")
+            arg.output_samples = [output_sample.replace('-', '').replace('_', '').replace('.', '').replace('/', '')
+                                  for output_sample in matching_count_samples]
+            output_samples_ids = None
+    else:
+        output_samples_ids = None
+        if arg.output_samples:
+            logging.error(
+                "--output-samples were specified but no --count-path was provided. Cannot extract desired sample expression.")
             sys.exit(1)
+
+
     return process_output_samples, output_samples_ids

--- a/immunopepper/translate.py
+++ b/immunopepper/translate.py
@@ -14,7 +14,7 @@ from immunopepper.namedtuples import Peptide
 from immunopepper.namedtuples import ReadingFrameTuple
 from immunopepper.utils import get_exon_expr,get_sub_mut_dna
 
-def get_full_peptide(gene, seq, cds_list, countinfo, seg_counts, Idx, mode, all_read_frames):
+def get_full_peptide(gene, seq, cds_list, countinfo, seg_counts=None, Idx=None, mode='full', all_read_frames=False):
     """
     Output translated peptide and segment expression list given cds_list
 

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -428,15 +428,15 @@ def retrieve_kmer_coordinates(start_pos_kmer, k, strand, spanning_index1, spanni
     :param k: int. len of the kmer
     :param spanning_index1: set. set of starting positions for which the kmer will cross junction 1
     :param spanning_index2: set. set of starting positions for which the kmer will cross junction 2
-    :param spanning_index1_2: set. set of starting positions for which the kmer will cross junction 1 and 2
+    :param spanning_index1_2: set. set of starting positions for which the kmer will cross junctions 1 and 2
     :param translation_sorted_coord: np.array. exon coordinates modified by reading frame in translation order
     :return: Coord namedtuples with:
     start_v1 = int. start genomic coordinate in exon 1 of the kmer (may not be exon 1 of the peptide)
     stop_v1 = int. stop genomic coordinate in exon 1 of the kmer (may not be exon 1 of the peptide)
     start_v2 = int. start genomic coordinate in exon 2 of the kmer (may not be exon 2 of the peptide)
     stop_v2 = int. stop genomic coordinate in exon 2 of the kmer (may not be exon 2 of the peptide)
-    start_v3 = int. start genomic coordinate in exon 3 of the kmer (may not be exon 3 of the peptide)
-    stop_v3 = int. stop genomic coordinate in exon 3 of the kmer (may not be exon 3 of the peptide)
+    start_v3 = int. start genomic coordinate in exon 3 of the kmer
+    stop_v3 = int. stop genomic coordinate in exon 3 of the kmer
     '''
 
     def shift_to_start(start_pos_kmer, strand, overhang=0, end_kmer=False):

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -318,7 +318,7 @@ def get_and_write_peptide_and_kmer(peptide_set=None,
                                                     peptide=peptide.mut[pep_idx],
                                                     exons_coor=modi_coord,
                                                     strand=gene.strand,
-                                                    read_frame_annotated=vertex_pair.read_frame.annotated_RF)  #TODO update with peptide file mode
+                                                    read_frame_annotated=vertex_pair.read_frame.annotated_RF)
 
                     ### kmers
                     if '2-exons' in kmer_type:
@@ -560,7 +560,7 @@ def create_kmer(output_peptide, k, gene_kmer_coord, kmer_database=None):
             if check_database:
                 kmer_coord = retrieve_kmer_coordinates(j, k, output_peptide.strand, spanning_index1, spanning_index2,
                                                        spanning_index1_2, sort_coord)
-                gene_kmer_coord.add((kmer_coord, kmer_peptide))
+                gene_kmer_coord.add((kmer_coord, kmer_peptide, output_peptide.read_frame_annotated))
 
 
 def prepare_output_kmer(gene, idx, countinfo, seg_counts, edge_idxs, edge_counts,
@@ -589,7 +589,7 @@ def prepare_output_kmer(gene, idx, countinfo, seg_counts, edge_idxs, edge_counts
     kmer_matrix_segm = []
     logging.info('Start going through kmers')
     logging.info(f'hello: {len(gene_kmer_coord)} kmers for {gene.name}')
-    for kmer_coord, kmer_peptide in gene_kmer_coord:
+    for kmer_coord, kmer_peptide, rf_annot in gene_kmer_coord:
         k = len(kmer_peptide)
 
         # segment expression
@@ -620,8 +620,6 @@ def prepare_output_kmer(gene, idx, countinfo, seg_counts, edge_idxs, edge_counts
                 jx2 = ':'.join([str(i) for i in np.sort(kmer_coord[2:])[1:3]])
                 junction_annotated = (jx1 in gene_annot_jx) or (jx2 in gene_annot_jx)
 
-        rf_annot = None # TODO update reading frame
-
         # create output data
         row_metadata = [kmer_peptide, ':'.join([str(coord) for coord in kmer_coord]),
                         is_in_junction, junction_annotated, rf_annot]
@@ -639,6 +637,5 @@ def prepare_output_kmer(gene, idx, countinfo, seg_counts, edge_idxs, edge_counts
             logging.info('... Saving kmer_matrix edge')
             save_kmer_matrix(kmer_matrix_edge, None, graph_samples, filepointer, out_dir, verbose)
             kmer_matrix_edge.clear()
-
 
     save_kmer_matrix(kmer_matrix_edge, kmer_matrix_segm, graph_samples, filepointer, out_dir, verbose=True)

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -613,7 +613,7 @@ def prepare_output_kmer(gene, idx, countinfo, seg_counts, edge_idxs, edge_counts
         sublist_seg = sublist_seg[0].tolist() #TODO cross sample mode. Where are the right samples subseted??
 
         # junction expression
-        if countinfo is not None: # kmer crosses only one exon
+        if (countinfo is not None) and (kmer_coord.start_v2 is not np.nan): # kmer crosses only one exon
             _, edges_expr = search_edge_metadata_segmentgraph(gene, kmer_coord, edge_idxs, edge_counts)
 
             sublist_jun = np.nanmin(edges_expr, axis=0) # always apply. The min has no effect if one junction only

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -450,17 +450,27 @@ def retrieve_kmer_coordinates(start_pos_kmer, k, strand, spanning_index1, spanni
 
     start_E1_modi, stop_E1_modi, start_E2_modi, stop_E2_modi, start_E3_modi, stop_E3_modi = translation_sorted_coord
 
-    pos_after_jx1 = max(spanning_index1) + 1
+    # get the position(s) right after the junction(s)
+    if spanning_index1:
+        pos_after_jx1 = max(spanning_index1) + 1
+    else:
+        pos_after_jx1 = np.nan
+    if spanning_index2:
+        pos_after_jx2 = max(spanning_index2) + 1
+    else:
+        pos_after_jx2 = np.nan
+
+    # get the overhang
     if (abs(stop_E1_modi - start_E1_modi) % 3): #TODO elegance code?
         overhang1 = 3 - (abs(stop_E1_modi - start_E1_modi) % 3)
     else:
         overhang1 = 0
-    pos_after_jx2 = max(spanning_index2) + 1
     if ((abs(stop_E1_modi - start_E1_modi) + abs(stop_E2_modi - start_E2_modi)) % 3):
         overhang2 = 3 - ((abs(stop_E1_modi - start_E1_modi) + abs(stop_E2_modi - start_E2_modi)) % 3)
     else:
         overhang2 = 0
 
+    # get the number of nucleotides from the kmer relative to the junction(s)
     nt_kmer_left_jx1 = ((pos_after_jx1 - start_pos_kmer) * 3 ) - overhang1 #number of nucleotides before jx1 from the kmer
     nt_kmer_right_jx1 = ((k - (pos_after_jx1 - start_pos_kmer)) * 3 ) + overhang1
     nt_kmer_left_jx2 = ((pos_after_jx2 - start_pos_kmer) * 3) - overhang2

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -256,7 +256,7 @@ def get_and_write_peptide_and_kmer(peptide_set=None,
     # as a  junction of a protein coding transcript
     gene_annot_jx = junction_is_annotated(gene, table.gene_to_ts, table.ts_to_cds)
     som_exp_dict = exon_to_expression(gene, list(mutation.somatic_dict.keys()), countinfo, seg_counts, mut_count_id)
-    gene_kmer_coord = {}
+    gene_kmer_coord = set()
     logging.info('start get_and_write_kmer')
     ### iterate over all vertex pairs and translate
     for kmer_type, vertex_pairs in all_vertex_pairs.items():
@@ -560,7 +560,7 @@ def create_kmer(output_peptide, k, gene_kmer_coord, kmer_database=None):
             if check_database:
                 kmer_coord = retrieve_kmer_coordinates(j, k, output_peptide.strand, spanning_index1, spanning_index2,
                                                        spanning_index1_2, sort_coord)
-                gene_kmer_coord[kmer_coord] = kmer_peptide
+                gene_kmer_coord.add((kmer_coord, kmer_peptide))
 
 
 def prepare_output_kmer(gene, idx, countinfo, seg_counts, edge_idxs, edge_counts,
@@ -589,13 +589,13 @@ def prepare_output_kmer(gene, idx, countinfo, seg_counts, edge_idxs, edge_counts
     kmer_matrix_segm = []
     logging.info('Start going through kmers')
     logging.info(f'hello: {len(gene_kmer_coord)} kmers for {gene.name}')
-    for kmer_coord, kmer_peptide in gene_kmer_coord.items():
+    for kmer_coord, kmer_peptide in gene_kmer_coord:
         k = len(kmer_peptide)
 
         # segment expression
         _, pos_expr_segm = get_segment_expr(gene, kmer_coord, countinfo, idx, seg_counts)
         sublist_seg = np.round(np.atleast_2d(pos_expr_segm[:, 0]).dot(pos_expr_segm[:, 1:]) / (k * 3), 2)
-        sublist_seg = sublist_seg[0].tolist() #TODO cross sample mode. Where are the right samples subseted??
+        sublist_seg = sublist_seg[0].tolist()
 
         # junction expression
         if (countinfo is not None) and (kmer_coord.start_v2 is not np.nan): # kmer crosses only one exon

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -628,11 +628,9 @@ def prepare_output_kmer(gene, idx, countinfo, seg_counts, edge_idxs, edge_counts
 
         # save output data per batch #TODO check feasibility of less batches for memory
         if len(kmer_matrix_segm) > 1000: # small but dense
-            logging.info('... Saving kmer_matrix segm')
             save_kmer_matrix(None, kmer_matrix_segm, graph_samples, filepointer, out_dir, verbose=False)
             kmer_matrix_segm.clear()
         if len(kmer_matrix_edge) > 1000: # big but relatively sparse
-            logging.info('... Saving kmer_matrix edge')
             save_kmer_matrix(kmer_matrix_edge, None, graph_samples, filepointer, out_dir, verbose)
             kmer_matrix_edge.clear()
 

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -257,7 +257,7 @@ def get_and_write_peptide_and_kmer(peptide_set=None,
     gene_annot_jx = junction_is_annotated(gene, table.gene_to_ts, table.ts_to_cds)
     som_exp_dict = exon_to_expression(gene, list(mutation.somatic_dict.keys()), countinfo, seg_counts, mut_count_id)
     gene_kmer_coord = set()
-    logging.info('start get_and_write_kmer')
+
     ### iterate over all vertex pairs and translate
     for kmer_type, vertex_pairs in all_vertex_pairs.items():
         for ii,vertex_pair in enumerate(vertex_pairs):
@@ -587,8 +587,6 @@ def prepare_output_kmer(gene, idx, countinfo, seg_counts, edge_idxs, edge_counts
     '''
     kmer_matrix_edge = []
     kmer_matrix_segm = []
-    logging.info('Start going through kmers')
-    logging.info(f'hello: {len(gene_kmer_coord)} kmers for {gene.name}')
     for kmer_coord, kmer_peptide, rf_annot in gene_kmer_coord:
         k = len(kmer_peptide)
 
@@ -631,11 +629,11 @@ def prepare_output_kmer(gene, idx, countinfo, seg_counts, edge_idxs, edge_counts
         # save output data per batch #TODO check feasibility of less batches for memory
         if len(kmer_matrix_segm) > 1000: # small but dense
             logging.info('... Saving kmer_matrix segm')
-            save_kmer_matrix(None, kmer_matrix_segm, graph_samples, filepointer, out_dir, verbose=True)
+            save_kmer_matrix(None, kmer_matrix_segm, graph_samples, filepointer, out_dir, verbose=False)
             kmer_matrix_segm.clear()
         if len(kmer_matrix_edge) > 1000: # big but relatively sparse
             logging.info('... Saving kmer_matrix edge')
             save_kmer_matrix(kmer_matrix_edge, None, graph_samples, filepointer, out_dir, verbose)
             kmer_matrix_edge.clear()
 
-    save_kmer_matrix(kmer_matrix_edge, kmer_matrix_segm, graph_samples, filepointer, out_dir, verbose=True)
+    save_kmer_matrix(kmer_matrix_edge, kmer_matrix_segm, graph_samples, filepointer, out_dir, verbose=False)

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -455,12 +455,14 @@ def retrieve_kmer_coordinates(start_pos_kmer, k, strand, spanning_index1, spanni
         pos_after_jx2 = np.nan
 
     # get the overhang
-    if (abs(stop_E1_modi - start_E1_modi) % 3): #TODO elegance code?
-        overhang1 = 3 - (abs(stop_E1_modi - start_E1_modi) % 3)
+    len_E1_modi = abs(stop_E1_modi - start_E1_modi)
+    len_E2_modi = abs(stop_E2_modi - start_E2_modi)
+    if (len_E1_modi % 3):
+        overhang1 = 3 - (len_E1_modi % 3)
     else:
         overhang1 = 0
-    if ((abs(stop_E1_modi - start_E1_modi) + abs(stop_E2_modi - start_E2_modi)) % 3):
-        overhang2 = 3 - ((abs(stop_E1_modi - start_E1_modi) + abs(stop_E2_modi - start_E2_modi)) % 3)
+    if ((len_E1_modi + len_E2_modi) % 3):
+        overhang2 = 3 - ((len_E1_modi + len_E2_modi) % 3)
     else:
         overhang2 = 0
 

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -4,7 +4,7 @@ import numpy as np
 import logging
 
 from immunopepper.filter import filter_redundant_junctions
-from immunopepper.filter import junction_is_annotated
+from immunopepper.filter import junctions_annotated
 from immunopepper.filter import is_intron_in_junction_list
 from immunopepper.io_ import namedtuple_to_str
 from immunopepper.io_ import save_kmer_matrix
@@ -254,7 +254,7 @@ def get_and_write_peptide_and_kmer(peptide_set=None,
     """
     # check whether the junction (specific combination of vertices) also is annotated
     # as a  junction of a protein coding transcript
-    gene_annot_jx = junction_is_annotated(gene, table.gene_to_ts, table.ts_to_cds)
+    gene_annot_jx = junctions_annotated(gene, table.gene_to_ts, table.ts_to_cds)
     som_exp_dict = exon_to_expression(gene, list(mutation.somatic_dict.keys()), countinfo, seg_counts, mut_count_id)
     gene_kmer_coord = set()
 

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -453,8 +453,10 @@ def retrieve_kmer_coordinates(start_pos_kmer, k, strand, spanning_index1, spanni
     # get the position(s) right after the junction(s)
     if spanning_index1:
         pos_after_jx1 = max(spanning_index1) + 1
+        first_cross_jx1 = min(spanning_index1)
     else:
         pos_after_jx1 = np.nan
+        first_cross_jx1 = np.nan
     if spanning_index2:
         pos_after_jx2 = max(spanning_index2) + 1
     else:
@@ -506,12 +508,12 @@ def retrieve_kmer_coordinates(start_pos_kmer, k, strand, spanning_index1, spanni
         stop_kmer_E2 = start_E3_modi + nt_kmer_right_jx2
 
     # Not cross junction: Before first junction
-    elif start_pos_kmer < min(spanning_index1) or np.isnan(pos_after_jx1):
+    elif start_pos_kmer < first_cross_jx1 or np.isnan(pos_after_jx1):
         start_kmer_E1 = start_E1_modi + shift_to_start(start_pos_kmer, strand)
         stop_kmer_E1 = start_E1_modi + shift_to_start(start_pos_kmer, strand, end_kmer=True)
 
     # Not cross junction: After second junction
-    elif start_pos_kmer > max(spanning_index2):
+    elif start_pos_kmer >= pos_after_jx2:
         start_kmer_E1 = start_E3_modi + shift_to_start(start_pos_kmer - pos_after_jx2, strand, overhang2)
         stop_kmer_E1 = start_E3_modi + shift_to_start(start_pos_kmer - pos_after_jx2, strand, overhang2, end_kmer=True)
 

--- a/immunopepper/traversal.py
+++ b/immunopepper/traversal.py
@@ -293,15 +293,7 @@ def get_and_write_peptide_and_kmer(peptide_set=None,
                     else:
                         seg_exp_variant_comb = np.nan  # if no mutation or no count file,  the segment expression is .
 
-                    # collect expression data
-                    if  countinfo:
-                        segment_expr_meta, expr_list = get_segment_expr(gene, modi_coord, countinfo, idx, seg_counts) #TODO update with peptide file mode
-                    else:
-                        segment_expr_meta, expr_list = np.nan, None
-                    if countinfo and not flag.is_isolated and edge_counts is not None: ## Will flag is isolated overlap with edge_counts is None?
-                        edge_expr_meta, edge_expr = search_edge_metadata_segmentgraph(gene, modi_coord, edge_idxs, edge_counts) #TODO update with peptide file mode
-                    else:
-                        edge_expr_meta, edge_expr = np.nan, np.nan
+
                     ### Peptides
                     peptide_set.add(namedtuple_to_str(OutputMetadata(peptide=peptide.mut[pep_idx],
                                        output_id=new_output_id,
@@ -311,7 +303,6 @@ def get_and_write_peptide_and_kmer(peptide_set=None,
                                        gene_chr=gene.chr,
                                        gene_strand=gene.strand,
                                        mutation_mode=mutation.mode,
-                                       junction_annotated=None, #TODO update
                                        has_stop_codon=int(flag.has_stop),
                                        is_in_junction_list=is_intron_in_junction_list_flag,
                                        is_isolated=int(flag.is_isolated),
@@ -320,8 +311,6 @@ def get_and_write_peptide_and_kmer(peptide_set=None,
                                        modified_exons_coord=modi_coord,
                                        original_exons_coord=vertex_pair.original_exons_coord,
                                        vertex_idx=vertex_list,
-                                       junction_expr=edge_expr_meta,
-                                       segment_expr=segment_expr_meta,
                                        kmer_type=kmer_type
                                        ), sep = '\t'))
                     variant_id += 1
@@ -329,8 +318,6 @@ def get_and_write_peptide_and_kmer(peptide_set=None,
                                                     peptide=peptide.mut[pep_idx],
                                                     exons_coor=modi_coord,
                                                     strand=gene.strand,
-                                                    junction_expr=edge_expr,
-                                                    junction_annotated=None, #TODO update
                                                     read_frame_annotated=vertex_pair.read_frame.annotated_RF)  #TODO update with peptide file mode
 
                     ### kmers
@@ -425,8 +412,6 @@ def get_and_write_background_peptide_and_kmer(peptide_set, kmer_set, gene, ref_m
                               peptide=cds_peptide,
                               exons_coor=None,
                               strand=None,
-                              junction_expr=None,
-                              junction_annotated=None,
                               read_frame_annotated=None)
             peptide_set.add(namedtuple_to_str(peptide, sep = '\t'))
 

--- a/immunopepper/utils.py
+++ b/immunopepper/utils.py
@@ -214,7 +214,7 @@ def get_exon_expr(gene, vstart, vstop, countinfo, Idx, seg_counts):
 
     """
     if countinfo is None:
-        return np.zeros((0, 1), dtype='float') #[np.nan]
+        return np.zeros((0, 1), dtype='float') #[np.nan] #TODO replace with nan?
 
     out_shape = (seg_counts.shape[1] + 1) if len(seg_counts.shape) > 1 else 2
     if vstart is np.nan or vstop is np.nan:  # isolated exon case
@@ -241,7 +241,7 @@ def get_exon_expr(gene, vstart, vstop, countinfo, Idx, seg_counts):
             expr_list = expr_list[::-1]
     return expr_list
 
-def get_segment_expr(gene, coord, countinfo, Idx, seg_counts, cross_graph_expr):
+def get_segment_expr(gene, coord, countinfo, Idx, seg_counts):
     """ Get the segment expression for one exon-pair.
     Apply 'get_exon_expr' for each exon and concatenate them.
 
@@ -279,12 +279,11 @@ def get_segment_expr(gene, coord, countinfo, Idx, seg_counts, cross_graph_expr):
     n_samples = expr_list[:, 1:].shape[1]
     len_factor = np.tile(expr_list[:, 0], n_samples).reshape(n_samples, expr_list.shape[0]).transpose()
     mean_expr = (np.sum(expr_list[:, 1:]*len_factor, 0) / seg_len).astype(int) if seg_len > 0 else np.zeros(n_samples).astype(int)
-    if not cross_graph_expr:
-        expr_meta_file = mean_expr[0]
+
     return expr_meta_file, expr_list
 
 
-def get_total_gene_expr(gene, countinfo, Idx, seg_expr, cross_graph_expr):
+def get_total_gene_expr(gene, countinfo, seg_expr):
     """ get total reads count for the given sample and the given gene
     actually total_expr = reads_length*total_reads_counts
     """
@@ -297,11 +296,8 @@ def get_total_gene_expr(gene, countinfo, Idx, seg_expr, cross_graph_expr):
         return [np.nan] * n_samples
     seg_len = gene.segmentgraph.segments[1] - gene.segmentgraph.segments[0]
 
-    if cross_graph_expr:
-        total_expr = np.sum(seg_len * seg_expr.T, axis=1)
-        total_expr = total_expr.tolist()
-    else:
-        total_expr = [np.sum(seg_len*seg_expr)]
+    total_expr = np.sum(seg_len * seg_expr.T, axis=1)
+    total_expr = total_expr.tolist()
     return total_expr
 
 

--- a/immunopepper/utils.py
+++ b/immunopepper/utils.py
@@ -237,7 +237,7 @@ def get_exon_expr(gene, vstart, vstop, countinfo, Idx, seg_counts):
             expr_list = np.c_[segments[1, sv1_id:sv2_id + 1] - segments[0, sv1_id:sv2_id + 1], seg_counts[sv1_id:sv2_id + 1, np.newaxis]]
         expr_list[0, 0] -= (vstart - segments[0, sv1_id])
         expr_list[-1, 0] -= (segments[1, sv2_id] - vstop)
-        if gene.strand == '-': # need to reverse epression list to match the order of translation
+        if gene.strand == '-': # need to reverse expression list to match the order of translation
             expr_list = expr_list[::-1]
     return expr_list
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -7,7 +7,7 @@ from spladder.classes.gene import Gene
 from spladder.classes.splicegraph import Splicegraph
 
 import immunopepper.filter as filter
-from immunopepper.namedtuples import Coord, OutputKmer, OutputMetadata, ReadingFrameTuple, VertexPair
+from immunopepper.namedtuples import Coord, OutputKmer, ReadingFrameTuple, VertexPair
 
 
 class TestFilterRedundantJunctions:
@@ -98,26 +98,14 @@ class TestJunctionIsAnnotated:
 
     def test_gene_absent(self, gene, gene_to_transcript, transcript_to_cds):
         gene.name = 'doesnt exist'
-        assert not np.any(filter.junction_is_annotated(gene, gene_to_transcript, transcript_to_cds))
-
-    def test_gene_present_empty_graph(self, gene, gene_to_transcript, transcript_to_cds):
-        assert not np.any(filter.junction_is_annotated(gene, gene_to_transcript, transcript_to_cds))
+        assert not filter.junction_is_annotated(gene, gene_to_transcript, transcript_to_cds)
 
     def test_one_junction_present(self, gene, gene_to_transcript, transcript_to_cds):
-        # the third transcript of our gene (ENSMUST00000192650.5) has two junctions:
-        # ['4492668:4493771', '4493863:4495135']; let's create a graph that has one of these junctions
-        gene.splicegraph.vertices = np.array([[4491718, 4493771, 4495135], [123456, 4493863, 4495155]], dtype='int')
-        gene.splicegraph.edges = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype='int')
-        expected = np.array([[False, False, False], [False, False, True], [False, True, False]])
-        assert np.array_equal(expected, filter.junction_is_annotated(gene, gene_to_transcript, transcript_to_cds))
-
-    def test_two_junctions_present(self, gene, gene_to_transcript, transcript_to_cds):
-        # the third transcript of our gene (ENSMUST00000192650.5) has two junctions:
-        # ['4492668:4493771', '4493863:4495135']; let's create a graph that has *both* of these junctions
-        gene.splicegraph.vertices = np.array([[4491718, 4493771, 4495135], [4492668, 4493863, 4495155]], dtype='int')
-        gene.splicegraph.edges = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype='int')
-        expected = np.array([[False, True, False], [True, False, True], [False, True, False]])
-        assert np.array_equal(expected, filter.junction_is_annotated(gene, gene_to_transcript, transcript_to_cds))
+        # the first transcript of our gene (ENSMUST00000027035.95) has one junction: ['4492668:4493099'];
+        # the second transcript of our gene (ENSMUST00000195555.1) has no junction:
+        # the third transcript of our gene (ENSMUST00000192650.5) has two junctions: ['4492668:4493771', '4493863:4495135'];
+        expected = set(['4492668:4493771', '4493863:4495135', '4492668:4493099'])
+        assert expected == filter.junction_is_annotated(gene, gene_to_transcript, transcript_to_cds)
 
 
 def test_junction_tuple_is_annotated():

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -69,8 +69,8 @@ class TestFilterRedundantJunctions:
         assert filtered_vertex_pairs == [vertex_pairs[1]]
 
 
-class TestJunctionIsAnnotated:
-    """ Tests for :meth:`filter.junction_is_annotated` """
+class TestJunctionsAnnotated:
+    """ Tests for :meth:`filter.junctions_annotated` """
 
     @pytest.fixture
     def gene(self):
@@ -98,14 +98,14 @@ class TestJunctionIsAnnotated:
 
     def test_gene_absent(self, gene, gene_to_transcript, transcript_to_cds):
         gene.name = 'doesnt exist'
-        assert not filter.junction_is_annotated(gene, gene_to_transcript, transcript_to_cds)
+        assert not filter.junctions_annotated(gene, gene_to_transcript, transcript_to_cds)
 
     def test_one_junction_present(self, gene, gene_to_transcript, transcript_to_cds):
         # the first transcript of our gene (ENSMUST00000027035.95) has one junction: ['4492668:4493099'];
         # the second transcript of our gene (ENSMUST00000195555.1) has no junction:
         # the third transcript of our gene (ENSMUST00000192650.5) has two junctions: ['4492668:4493771', '4493863:4495135'];
         expected = set(['4492668:4493771', '4493863:4495135', '4492668:4493099'])
-        assert expected == filter.junction_is_annotated(gene, gene_to_transcript, transcript_to_cds)
+        assert expected == filter.junctions_annotated(gene, gene_to_transcript, transcript_to_cds)
 
 
 def test_junction_tuple_is_annotated():

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -41,7 +41,7 @@ def test_end_to_end_build_mouse(tmpdir, mutation_mode, is_parallel=True, graph_c
                 #'--kmer-database', os.path.join(data_dir, 'uniprot_test.csv'),
                 #'--libsize-extract',
                #'--disable-process-libsize',
-               '--output-samples', 'ERR2130621', #ERR2130621',# 'ENCSR000BZG'
+               '--output-samples', 'ENCSR000BZG', #ERR2130621',# 'ENCSR000BZG'
                #'--mutation-sample', 'ERR2130621',
                #'--pickle-samples', 'ERR2130621',
                '--output-dir', out_dir,

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -41,7 +41,7 @@ def test_end_to_end_build_mouse(tmpdir, mutation_mode, is_parallel=True, graph_c
                 #'--kmer-database', os.path.join(data_dir, 'uniprot_test.csv'),
                 #'--libsize-extract',
                #'--disable-process-libsize',
-               '--output-samples', 'ENCSR000BZG',  #'ERR2130621','ENCSR000BZG'
+               '--output-samples', 'ERR2130621', #ERR2130621',# 'ENCSR000BZG'
                #'--mutation-sample', 'ERR2130621',
                #'--pickle-samples', 'ERR2130621',
                '--output-dir', out_dir,
@@ -243,7 +243,7 @@ mutation_mode ='ref'
 #pr = cProfile.Profile()
 #pr.enable()
 #for mutation_mode in ['ref', 'somatic', 'germline', 'somatic_and_germline']:
-test_end_to_end_build_mouse(tmpdir, mutation_mode, is_parallel=False, graph_cross_sample=True) #TODO add back
+test_end_to_end_build_mouse(tmpdir, mutation_mode, is_parallel=False) #TODO add back
 #test_end_to_end_samplespecif('ERR2130621', tmpdir, "9", mutation_mode) # TEST DEPRECATED
 #test_end_to_end_filter(tmpdir, 'ERR2130621', "9", mutation_mode)
 #for mutation_mode in ['ref', 'germline', 'somatic', 'somatic_and_germline']:


### PR DESCRIPTION
This commits builds on: 
development + lightweight + lightweight_simplyfywrite_legacy_partitions branches
**It aims at moving the unicity on the kmer before the slicing/computation of the expression.** 

For each gene

- **Peptides** are **generated** 

- The peptides are **sliced into kmers**

- The kmers are **matched** against a database (uniprot) 

- **The kmer coordinates** are extracted. I introduce the function retrieve_kmer_coordinates. The different edge cases related to this function have been tested. 

- The kmers are added to a dictionary of {coord : kmer } (in this case "coord" is not a string but a namedtuple)

Then the dictionary of kmers is traversed 

- the segment expression

- junction expression

- additional flags are extracted in a kmer centric way (before the algorithm was peptide centric)
The consistency with the previous implementation of segment and junction expression values was tested. 

Finally, the output is built on the fly and dumped to disk once it reaches a certain size